### PR TITLE
Add External Engine API methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ clap = { version = "4.4.11", features = ["derive"] }
 color-eyre = "0.6.2"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+rand = "0.8.4"
+
+# [features]
+# awc = ["dep:actix-web", "dep:awc", "dep:webpki-roots", "dep:mime", "dep:rustls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,3 @@ tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 rand = "0.8.4"
 
-# [features]
-# awc = ["dep:actix-web", "dep:awc", "dep:webpki-roots", "dep:mime", "dep:rustls"]

--- a/examples/lichess.rs
+++ b/examples/lichess.rs
@@ -216,21 +216,6 @@ struct UpdateExternalEngineArgs {
     provider_data: Option<String>,
 }
 
-// {
-//     "clientSecret": "ees_mdF2hK0hlKGSPeC6",
-//       "sessionId": "abcd1234",
-//       "threads": 4,
-//       "hash": 128,
-//       "infinite": false,
-//       "multiPv": 1,
-//       "variant": "chess",
-//       "initialFen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-//       "moves": [
-//         "e2e4",
-//         "g8f6"
-//       ]
-//   }
-
 #[derive(Debug, Parser)]
 struct AnalyseArgs {
     /// The external engine id

--- a/examples/lichess.rs
+++ b/examples/lichess.rs
@@ -333,10 +333,10 @@ impl ExternalEngineCommand {
             } => {
                 let acquire_analysis = acquire_analysis::AcquireAnalysis { provider_secret };
                 let request = acquire_analysis::PostRequest::new(acquire_analysis);
-                let mut analysis = lichess.aquire_analysis_request(request.clone()).await?;
+                let mut analysis = lichess.acquire_analysis_request(request.clone()).await?;
                 while wait && analysis.is_none() {
                     tracing::debug!("No analysis request available");
-                    analysis = lichess.aquire_analysis_request(request.clone()).await?;
+                    analysis = lichess.acquire_analysis_request(request.clone()).await?;
                 }
                 println!("{:#?}", analysis);
                 Ok(())

--- a/examples/lichess.rs
+++ b/examples/lichess.rs
@@ -4,7 +4,9 @@ use clap::{Parser, Subcommand};
 use color_eyre::Result;
 use futures::StreamExt;
 use lichess_api::client::LichessApi;
-use lichess_api::model::puzzles::*;
+use lichess_api::model::external_engine::{self, *};
+use lichess_api::model::puzzles::{self, *};
+use rand::Rng;
 use reqwest;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -35,6 +37,10 @@ enum Command {
     Puzzle {
         #[clap(subcommand)]
         command: PuzzleCommand,
+    },
+    Engine {
+        #[clap(subcommand)]
+        command: ExternalEngineCommand,
     },
 }
 
@@ -82,6 +88,7 @@ impl App {
     async fn run(self, args: Cli) -> Result<()> {
         match args.command {
             Command::Puzzle { command } => command.run(self.lichess).await,
+            Command::Engine { command } => command.run(self.lichess).await,
         }
     }
 }
@@ -110,7 +117,7 @@ impl PuzzleCommand {
                 Ok(())
             }
             PuzzleCommand::Get { id } => {
-                let request = id::GetRequest::new(&id);
+                let request = puzzles::id::GetRequest::new(&id);
                 let puzzle = lichess.get_puzzle(request).await?;
                 println!("{puzzle:#?}");
                 Ok(())
@@ -138,4 +145,228 @@ impl PuzzleCommand {
             }
         }
     }
+}
+
+#[derive(Debug, Subcommand)]
+enum ExternalEngineCommand {
+    /// Lists all external engines that have been registered for the user, and the credentials required to use them.
+    List,
+    /// Registers a new external engine for the user. It can then be selected and used on the analysis board.
+    Create(CreateExternalEngineArgs),
+    /// Get properties and credentials of an external engine.
+    Get { id: String },
+    /// Updates the properties of an external engine.
+    Update(UpdateExternalEngineArgs),
+    /// Unregisters an external engine.
+    Delete { id: String },
+    /// Request analysis from an external engine.
+    Analyse(AnalyseArgs),
+    /// Wait for an analysis requests to any of the external engines that have been registered with the given secret.
+    AcquireAnalysis {
+        provider_secret: String,
+        /// Loop and wait for analysis requests
+        #[arg(long, short)]
+        wait: bool,
+    },
+}
+
+#[derive(Debug, Parser)]
+struct CreateExternalEngineArgs {
+    /// Display name of the engine
+    #[arg(long, short)]
+    name: String,
+    /// Maximum number of available threads
+    #[arg(long, short = 't')]
+    max_threads: u32,
+    /// Maximum available hash table size, in MiB
+    #[arg(long, short = 'm')]
+    max_hash: u32,
+    /// Estimated depth of normal search
+    #[arg(long, short)]
+    default_depth: u8,
+    /// Optional list of supported chess variants
+    #[arg(long, short)]
+    variants: Option<Vec<String>>,
+    /// Arbitrary data that the engine provider can use for identification or bookkeeping
+    #[arg(long, short)]
+    provider_data: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+struct UpdateExternalEngineArgs {
+    // The external engine id
+    id: String,
+    /// Display name of the engine
+    #[arg(long, short)]
+    name: String,
+    /// Maximum number of available threads
+    #[arg(long, short = 't')]
+    max_threads: u32,
+    /// Maximum available hash table size, in MiB
+    #[arg(long, short = 'm')]
+    max_hash: u32,
+    /// Estimated depth of normal search
+    #[arg(long, short)]
+    default_depth: u8,
+    /// Optional list of supported chess variants
+    #[arg(long, short)]
+    variants: Option<Vec<String>>,
+    /// Arbitrary data that the engine provider can use for identification or bookkeeping
+    #[arg(long, short)]
+    provider_data: Option<String>,
+}
+
+// {
+//     "clientSecret": "ees_mdF2hK0hlKGSPeC6",
+//       "sessionId": "abcd1234",
+//       "threads": 4,
+//       "hash": 128,
+//       "infinite": false,
+//       "multiPv": 1,
+//       "variant": "chess",
+//       "initialFen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+//       "moves": [
+//         "e2e4",
+//         "g8f6"
+//       ]
+//   }
+
+#[derive(Debug, Parser)]
+struct AnalyseArgs {
+    /// The external engine id
+    id: String,
+    /// The client secret for the engine
+    #[arg(long, short)]
+    client_secret: String,
+    /// The session id
+    #[arg(long, short)]
+    session_id: String,
+    /// Number of threads to use
+    #[arg(long, short = 't')]
+    threads: u32,
+    /// Hash table size in MiB
+    #[arg(long, short = 'm')]
+    hash: u32,
+    /// Whether to analyse infinitely
+    #[arg(long, short)]
+    infinite: bool,
+    /// Number of principal variations to return
+    #[arg(long, short = 'p')]
+    pv: u8,
+    /// The variant to analyse
+    #[arg(long, short)]
+    variant: String,
+    /// The initial FEN
+    #[arg(long, short)]
+    fen: String,
+    /// The moves to analyse
+    #[arg(long, short = 'a')]
+    moves: Vec<String>,
+}
+
+impl ExternalEngineCommand {
+    async fn run(self, lichess: Lichess) -> Result<()> {
+        match self {
+            ExternalEngineCommand::List => {
+                let request = list::GetRequest::new();
+                let engines = lichess.list_external_engines(request).await?;
+                println!("{:#?}", engines);
+                Ok(())
+            }
+            ExternalEngineCommand::Get { id } => {
+                let request = external_engine::id::GetRequest::new(&id);
+                let engine = lichess.get_external_engine(request).await?;
+                println!("{:#?}", engine);
+                Ok(())
+            }
+            ExternalEngineCommand::Create(args) => {
+                let provider_secret = generate_provider_secret();
+                let engine = CreateExternalEngine {
+                    name: args.name,
+                    max_threads: args.max_threads,
+                    max_hash: args.max_hash,
+                    default_depth: args.default_depth,
+                    variants: args.variants,
+                    provider_data: args.provider_data,
+                    provider_secret: provider_secret.clone(),
+                };
+                let request = create::PostRequest::new(engine);
+                let engine = lichess.create_external_engine(request).await?;
+                println!("{:#?}", engine);
+                println!("provider_secret: {}", provider_secret);
+                Ok(())
+            }
+            ExternalEngineCommand::Update(args) => {
+                let provider_secret = generate_provider_secret();
+                let engine = UpdateExternalEngine {
+                    name: args.name,
+                    max_threads: args.max_threads,
+                    max_hash: args.max_hash,
+                    default_depth: args.default_depth,
+                    variants: args.variants,
+                    provider_data: args.provider_data,
+                    provider_secret: provider_secret.clone(),
+                };
+                let request = update::PutRequest::new(&args.id, engine);
+                let engine = lichess.update_external_engine(request).await?;
+                println!("{:#?}", engine);
+                println!("provider_secret: {}", provider_secret);
+                Ok(())
+            }
+            ExternalEngineCommand::Delete { id } => {
+                let request = delete::DeleteRequest::new(&id);
+                let ok = lichess.delete_external_engine(request).await?;
+                println!("Deleted engine {}. {}", id, ok);
+                Ok(())
+            }
+            ExternalEngineCommand::Analyse(args) => {
+                let analysis_request = analyse::AnalysisRequest {
+                    client_secret: args.client_secret,
+                    work: analyse::ExternalEngineWork {
+                        session_id: args.session_id,
+                        threads: args.threads,
+                        hash: args.hash,
+                        infinite: args.infinite,
+                        multi_pv: args.pv,
+                        variant: args.variant,
+                        initial_fen: args.fen,
+                        moves: args.moves,
+                    },
+                };
+                let request = analyse::PostRequest::new(&args.id, analysis_request);
+                tracing::debug!("{:#?}", request);
+                let mut stream = lichess.analyse_with_external_engine(request).await?;
+                while let Some(analysis) = stream.next().await {
+                    let analysis = analysis?;
+                    println!("{:#?}", analysis);
+                }
+                Ok(())
+            }
+            ExternalEngineCommand::AcquireAnalysis {
+                provider_secret,
+                wait,
+            } => {
+                let acquire_analysis = acquire_analysis::AcquireAnalysis { provider_secret };
+                let request = acquire_analysis::PostRequest::new(acquire_analysis);
+                let mut analysis = lichess.aquire_analysis_request(request.clone()).await?;
+                while wait && analysis.is_none() {
+                    tracing::debug!("No analysis request available");
+                    analysis = lichess.aquire_analysis_request(request.clone()).await?;
+                }
+                println!("{:#?}", analysis);
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Generate a random provider secret for the engine
+/// This is used to authenticate the engine with the lichess server
+fn generate_provider_secret() -> String {
+    let provider_secret = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect::<String>();
+    provider_secret
 }

--- a/src/api/external_engine.rs
+++ b/src/api/external_engine.rs
@@ -17,7 +17,6 @@ impl LichessApi<reqwest::Client> {
         &self,
         request: create::PostRequest,
     ) -> Result<ExternalEngine> {
-        debug!("Creating external engine: {:?}", request);
         self.get_single_model(request).await
     }
 

--- a/src/api/external_engine.rs
+++ b/src/api/external_engine.rs
@@ -43,7 +43,7 @@ impl LichessApi<reqwest::Client> {
         self.get_streamed_models(request).await
     }
 
-    pub async fn aquire_analysis_request(
+    pub async fn acquire_analysis_request(
         &self,
         request: acquire_analysis::PostRequest,
     ) -> Result<Option<acquire_analysis::AcquireAnalysisResponse>> {

--- a/src/api/external_engine.rs
+++ b/src/api/external_engine.rs
@@ -1,0 +1,55 @@
+use async_std::stream::StreamExt;
+use tracing::debug;
+
+use crate::client::LichessApi;
+use crate::error::Result;
+use crate::model::external_engine::*;
+
+impl LichessApi<reqwest::Client> {
+    pub async fn list_external_engines(
+        &self,
+        request: list::GetRequest,
+    ) -> Result<Vec<ExternalEngine>> {
+        self.get_single_model(request).await
+    }
+
+    pub async fn create_external_engine(
+        &self,
+        request: create::PostRequest,
+    ) -> Result<ExternalEngine> {
+        debug!("Creating external engine: {:?}", request);
+        self.get_single_model(request).await
+    }
+
+    pub async fn get_external_engine(&self, request: id::GetRequest) -> Result<ExternalEngine> {
+        self.get_single_model(request).await
+    }
+
+    pub async fn update_external_engine(
+        &self,
+        request: update::PutRequest,
+    ) -> Result<ExternalEngine> {
+        self.get_single_model(request).await
+    }
+
+    pub async fn delete_external_engine(&self, request: delete::DeleteRequest) -> Result<bool> {
+        self.get_ok(request).await
+    }
+
+    /// This method currently returns a 503 error (Service Unavailable) from the Lichess API
+    pub async fn analyse_with_external_engine(
+        &self,
+        request: analyse::PostRequest,
+    ) -> Result<impl StreamExt<Item = Result<analyse::AnalysisResponse>>> {
+        self.get_streamed_models(request).await
+    }
+
+    pub async fn aquire_analysis_request(
+        &self,
+        request: acquire_analysis::PostRequest,
+    ) -> Result<Option<acquire_analysis::AcquireAnalysisResponse>> {
+        let mut stream = self.get_streamed_models(request).await?;
+        // The response is a stream of 0 or 1 items, so we can just take the first item
+        Ok((stream.next().await).transpose()?)
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod board;
 pub mod bot;
 pub mod challenges;
+pub mod external_engine;
 pub mod games;
 pub mod messaging;
 pub mod puzzles;

--- a/src/model/external_engine/acquire_analysis.rs
+++ b/src/model/external_engine/acquire_analysis.rs
@@ -1,0 +1,61 @@
+use crate::model::{Body, Domain, Request};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery, AcquireAnalysis>;
+
+impl PostRequest {
+    pub fn new(acquire_analysis: AcquireAnalysis) -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::POST,
+            path: format!("/api/external-engine/work"),
+            query: Default::default(),
+            body: Body::Json(acquire_analysis),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcquireAnalysis {
+    pub provider_secret: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcquireAnalysisResponse {
+    pub id: String,
+    pub work: ExternalEngineWork,
+    pub engine: Engine,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalEngineWork {
+    pub session_id: String,
+    pub threads: u32,
+    pub hash: u32,
+    pub infinite: bool,
+    pub multi_pv: u8,
+    pub variant: String,
+    pub initial_fen: String,
+    pub moves: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Engine {
+    pub id: String,
+    pub name: String,
+    pub client_secret: String,
+    pub user_id: String,
+    pub max_threads: u32,
+    pub max_hash: u32,
+    pub default_depth: u8,
+    pub variants: Vec<String>,
+    pub provider_data: Option<String>,
+}

--- a/src/model/external_engine/analyse.rs
+++ b/src/model/external_engine/analyse.rs
@@ -1,0 +1,58 @@
+use crate::model::{Body, Domain, Request};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery, AnalysisRequest>;
+
+impl PostRequest {
+    pub fn new(id: &str, analysis_request: AnalysisRequest) -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::POST,
+            path: format!("/api/external-engine/{}/analyse", id),
+            query: Default::default(),
+            body: Body::Json(analysis_request),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalysisRequest {
+    pub client_secret: String,
+    pub work: ExternalEngineWork,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalEngineWork {
+    pub session_id: String,
+    pub threads: u32,
+    pub hash: u32,
+    pub infinite: bool,
+    pub multi_pv: u8,
+    pub variant: String,
+    pub initial_fen: String,
+    pub moves: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalysisResponse {
+    pub time: u64,
+    pub depth: u8,
+    pub nodes: u64,
+    pub pvs: Vec<PV>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PV {
+    pub depth: u8,
+    pub cp: i32,
+    pub mate: i32,
+    pub moves: Vec<String>,
+}

--- a/src/model/external_engine/create.rs
+++ b/src/model/external_engine/create.rs
@@ -1,5 +1,5 @@
 use crate::model::external_engine::CreateExternalEngine;
-use crate::model::{Body, Domain, Request};
+use crate::model::{Body, Request};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -11,11 +11,10 @@ pub type PostRequest = Request<PostQuery, CreateExternalEngine>;
 impl PostRequest {
     pub fn new(engine: CreateExternalEngine) -> Self {
         Self {
-            domain: Domain::Engine,
             method: http::Method::POST,
             path: "/api/external-engine".to_string(),
-            query: Default::default(),
             body: Body::Json(engine),
+            ..Default::default()
         }
     }
 }

--- a/src/model/external_engine/create.rs
+++ b/src/model/external_engine/create.rs
@@ -1,0 +1,35 @@
+use crate::model::external_engine::CreateExternalEngine;
+use crate::model::{Body, Domain, Request};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery, CreateExternalEngine>;
+
+impl PostRequest {
+    pub fn new(engine: CreateExternalEngine) -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::POST,
+            path: "/api/external-engine".to_string(),
+            query: Default::default(),
+            body: Body::Json(engine),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalEngine {
+    pub id: String,
+    pub name: String,
+    pub client_secret: String,
+    pub user_id: String,
+    pub max_threads: u32,
+    pub max_hash: u32,
+    pub default_depth: u8,
+    pub variants: Vec<String>,
+    pub provider_data: Option<String>,
+}

--- a/src/model/external_engine/delete.rs
+++ b/src/model/external_engine/delete.rs
@@ -1,0 +1,20 @@
+use crate::model::{Domain, Request};
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteQuery;
+
+pub type DeleteRequest = Request<DeleteQuery>;
+
+impl DeleteRequest {
+    pub fn new(id: &str) -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::DELETE,
+            path: format!("/api/external-engine/{}", id),
+            query: Default::default(),
+            body: Default::default(),
+        }
+    }
+}

--- a/src/model/external_engine/delete.rs
+++ b/src/model/external_engine/delete.rs
@@ -1,4 +1,4 @@
-use crate::model::{Domain, Request};
+use crate::model::Request;
 use serde::Serialize;
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -10,11 +10,9 @@ pub type DeleteRequest = Request<DeleteQuery>;
 impl DeleteRequest {
     pub fn new(id: &str) -> Self {
         Self {
-            domain: Domain::Engine,
             method: http::Method::DELETE,
             path: format!("/api/external-engine/{}", id),
-            query: Default::default(),
-            body: Default::default(),
+            ..Default::default()
         }
     }
 }

--- a/src/model/external_engine/id.rs
+++ b/src/model/external_engine/id.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::model::Domain;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery;
+
+pub type GetRequest = crate::model::Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(id: &str) -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::GET,
+            path: format!("/api/external-engine/{}", id),
+            query: Default::default(),
+            body: Default::default(),
+        }
+    }
+}
+
+pub type Engine = super::ExternalEngine;

--- a/src/model/external_engine/id.rs
+++ b/src/model/external_engine/id.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
 
-use crate::model::Domain;
-
 #[derive(Default, Clone, Debug, Serialize)]
 pub struct GetQuery;
 
@@ -10,11 +8,8 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 impl GetRequest {
     pub fn new(id: &str) -> Self {
         Self {
-            domain: Domain::Engine,
-            method: http::Method::GET,
             path: format!("/api/external-engine/{}", id),
-            query: Default::default(),
-            body: Default::default(),
+            ..Default::default()
         }
     }
 }

--- a/src/model/external_engine/list.rs
+++ b/src/model/external_engine/list.rs
@@ -1,0 +1,20 @@
+// use crate::model::external_engine::ExternalEngineJson;;
+use crate::model::{Domain, Request};
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery;
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new() -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::GET,
+            path: "/api/external-engine".to_string(),
+            query: Default::default(),
+            body: Default::default(),
+        }
+    }
+}

--- a/src/model/external_engine/list.rs
+++ b/src/model/external_engine/list.rs
@@ -1,5 +1,4 @@
-// use crate::model::external_engine::ExternalEngineJson;;
-use crate::model::{Domain, Request};
+use crate::model::Request;
 use serde::Serialize;
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -10,11 +9,8 @@ pub type GetRequest = Request<GetQuery>;
 impl GetRequest {
     pub fn new() -> Self {
         Self {
-            domain: Domain::Engine,
-            method: http::Method::GET,
             path: "/api/external-engine".to_string(),
-            query: Default::default(),
-            body: Default::default(),
+            ..Default::default()
         }
     }
 }

--- a/src/model/external_engine/mod.rs
+++ b/src/model/external_engine/mod.rs
@@ -1,0 +1,50 @@
+pub mod acquire_analysis;
+pub mod analyse;
+pub mod create;
+pub mod delete;
+pub mod id;
+pub mod list;
+pub mod update;
+
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalEngine {
+    pub id: String,
+    pub name: String,
+    pub client_secret: String,
+    pub user_id: String,
+    pub max_threads: u32,
+    pub max_hash: u32,
+    pub default_depth: u8,
+    pub variants: Vec<String>,
+    pub provider_data: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[skip_serializing_none]
+pub struct CreateExternalEngine {
+    pub name: String,
+    pub max_threads: u32,
+    pub max_hash: u32,
+    pub default_depth: u8,
+    pub variants: Option<Vec<String>>,
+    pub provider_secret: String,
+    pub provider_data: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[skip_serializing_none]
+pub struct UpdateExternalEngine {
+    pub name: String,
+    pub max_threads: u32,
+    pub max_hash: u32,
+    pub default_depth: u8,
+    pub variants: Option<Vec<String>>,
+    pub provider_secret: String,
+    pub provider_data: Option<String>,
+}

--- a/src/model/external_engine/update.rs
+++ b/src/model/external_engine/update.rs
@@ -1,0 +1,22 @@
+use crate::model::{Body, Domain, Request};
+use serde::Serialize;
+
+use super::UpdateExternalEngine;
+
+#[derive(Default, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PutQuery;
+
+pub type PutRequest = Request<PutQuery, UpdateExternalEngine>;
+
+impl PutRequest {
+    pub fn new(id: &str, engine: UpdateExternalEngine) -> Self {
+        Self {
+            domain: Domain::Engine,
+            method: http::Method::PUT,
+            path: format!("/api/external-engine/{}", id),
+            query: Default::default(),
+            body: Body::Json(engine),
+        }
+    }
+}

--- a/src/model/external_engine/update.rs
+++ b/src/model/external_engine/update.rs
@@ -1,4 +1,4 @@
-use crate::model::{Body, Domain, Request};
+use crate::model::{Body, Request};
 use serde::Serialize;
 
 use super::UpdateExternalEngine;
@@ -12,11 +12,10 @@ pub type PutRequest = Request<PutQuery, UpdateExternalEngine>;
 impl PutRequest {
     pub fn new(id: &str, engine: UpdateExternalEngine) -> Self {
         Self {
-            domain: Domain::Engine,
             method: http::Method::PUT,
             path: format!("/api/external-engine/{}", id),
-            query: Default::default(),
             body: Body::Json(engine),
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Builds on #12 - so if reviewing just read the last 2 commits:
- feat: add external engine API methods https://github.com/ion232/lichess-api/pull/14/commits/5f7bef4a02d3d21e55358e4d9f53d0cc0e230ce8 
- feat: add engine analyse https://github.com/ion232/lichess-api/pull/14/commits/bc579558c61b55ebc2f3cb2eda5d45434ed26b24

WORKING:
- create
- update
- list
- get
- delete

TODO:
- /engine/{id}/analyse gives a 404 currently (https://lichess.org/api#tag/External-engine/operation/apiExternalEngineAnalyse)
- https://lichess.org/api#tag/External-engine/operation/apiExternalEngineAcquire
- https://lichess.org/api#tag/External-engine/operation/apiExternalEngineSubmit (requires streaming POST - so this might be a bit more effort than the other methods)