### PR TITLE
Add support for importing PGN into study

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following table shows the current level of support for each category of endp
 | Puzzles               |   ✅    |
 | Relations             |   ❌    |
 | Simuls                |   ❌    |
-| Studies               |   ❌    |
+| Studies               |   🔶    |
 | Swiss Tournaments     |   ❌    |
 | Tablebase             |   ✅    |
 | Teams                 |   ❌    |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod games;
 pub mod messaging;
 pub mod openings;
 pub mod puzzles;
+pub mod studies;
 pub mod tablebase;
 pub mod users;
 

--- a/src/api/studies.rs
+++ b/src/api/studies.rs
@@ -1,0 +1,12 @@
+use crate::client::LichessApi;
+use crate::error::Result;
+use crate::model::studies::import_pgn_into_study::{PostRequest, StudyImportPgnChapters};
+
+impl LichessApi<reqwest::Client> {
+    pub async fn import_pgn_into_study(
+        &self,
+        request: PostRequest,
+    ) -> Result<StudyImportPgnChapters> {
+        self.get_single_model(request).await
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,6 +8,7 @@ pub mod games;
 pub mod messaging;
 pub mod openings;
 pub mod puzzles;
+pub mod studies;
 pub mod tablebase;
 pub mod users;
 

--- a/src/model/studies/import_pgn_into_study.rs
+++ b/src/model/studies/import_pgn_into_study.rs
@@ -1,0 +1,39 @@
+use crate::model::{Body, Request, VariantKey};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Default, Clone, Debug, Serialize)]
+#[skip_serializing_none]
+pub struct ImportPgnBody {
+    pub name: String,
+    pub pgn: String,
+    pub variant: Option<VariantKey>,
+    pub orientation: Option<String>,
+}
+
+#[derive(Default, Clone, Debug, Deserialize)]
+pub struct StudyImportPgnChapters {
+    pub chapters: Vec<StudyChapterListItem>,
+}
+
+#[derive(Default, Clone, Debug, Deserialize)]
+pub struct StudyChapterListItem {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery, ImportPgnBody>;
+
+impl PostRequest {
+    pub fn new(study_id: String, import_pgn_body: ImportPgnBody) -> Self {
+        Self {
+            method: http::Method::POST,
+            path: format!("/api/study/{}/import-pgn", study_id),
+            body: Body::Form(import_pgn_body),
+            ..Default::default()
+        }
+    }
+}

--- a/src/model/studies/mod.rs
+++ b/src/model/studies/mod.rs
@@ -1,0 +1,1 @@
+pub mod import_pgn_into_study;


### PR DESCRIPTION
This PR adds the ability to send a PGN into a study ([this endpoint](https://lichess.org/api#tag/Studies/operation/apiStudyImportPGN)).

I tested this (all chapters in [this study](https://lichess.org/study/Gz5dfSNQ) are imported using this code) with no issues.

I have begun work to implement the whole Studies API endpoint. However, the output of the Lichess API is very messy: we need to parse a non-standard data format (application/chess-x-pgn). You can see my first try in [this PR](https://github.com/yzoug/lichess-api/pull/2) (not mergeable).

Will maybe continue working on this but I think it won't be the most used feature of the Lichess API: it's way easier to consult studies directly on the Lichess interface. However, sending a PGN into a study is something more people would want to do (at least, I will need this for my project).

If someone wants to give it a go to implement the rest of the Studies API endpoint I can help! But as you can see in the linked PR above, it's a mess :/