### PR TITLE
fix: anonymous player deserialisation

### DIFF
--- a/src/model/board/stream/game.rs
+++ b/src/model/board/stream/game.rs
@@ -107,6 +107,7 @@ pub enum GameEventPlayer {
         #[serde(flatten)]
         human: GameEventHuman,
     },
+    Anonymous {},
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/challenges/mod.rs
+++ b/src/model/challenges/mod.rs
@@ -98,7 +98,10 @@ pub struct ChallengeJsonBase {
     pub direction: Option<Direction>,
     pub time_control: TimeControl,
     pub variant: Variant,
-    pub challenger: ChallengeUser,
+
+    /// The api docs suggest this is non-nullable,
+    /// this is true only if the user does not accept anonymous challengers.
+    pub challenger: Option<ChallengeUser>,
     pub compat: Option<Compat>,
     pub dest_user: Option<ChallengeUser>,
     pub perf: Perf,

--- a/tests/data/response/challenge_anonymous.json
+++ b/tests/data/response/challenge_anonymous.json
@@ -1,0 +1,39 @@
+{
+  "type": "challenge",
+  "challenge": {
+    "id": "7pGLxJ4F",
+    "url": "https://lichess.org/VU0nyvsW",
+    "status": "created",
+    "compat": {
+      "bot": false,
+      "board": true
+    },
+    "destUser": {
+      "id": "thibot",
+      "name": "thibot",
+      "title": null,
+      "rating": 1500,
+      "provisional": true,
+      "online": true,
+      "lag": 45
+    },
+    "variant": {
+      "key": "standard",
+      "name": "Standard",
+      "short": "Std"
+    },
+    "rated": true,
+    "timeControl": {
+      "type": "clock",
+      "limit": 300,
+      "increment": 25,
+      "show": "5+25"
+    },
+    "color": "random",
+    "speed": "rapid",
+    "perf": {
+      "icon": "#",
+      "name": "Rapid"
+    }
+  }
+}

--- a/tests/data/response/game_full_anonymous.json
+++ b/tests/data/response/game_full_anonymous.json
@@ -1,0 +1,33 @@
+{
+  "id": "TtAx77HD",
+  "variant": {
+    "key": "antichess",
+    "name": "Antichess",
+    "short": "Anti"
+  },
+  "speed": "correspondence",
+  "perf": {
+    "name": "Antichess"
+  },
+  "rated": false,
+  "createdAt": 1696590464597,
+  "white": {},
+  "black": {
+    "id": "tarr3n",
+    "name": "Tarr3n",
+    "title": null,
+    "rating": 1925,
+    "provisional": false
+  },
+  "initialFen": "startpos",
+  "type": "gameFull",
+  "state": {
+    "type": "gameState",
+    "moves": "",
+    "wtime": 2147483647,
+    "btime": 2147483647,
+    "winc": 0,
+    "binc": 0,
+    "status": "started"
+  }
+}

--- a/tests/response_models.rs
+++ b/tests/response_models.rs
@@ -44,6 +44,7 @@ pub fn challenge_ai() {
 
 #[test]
 pub fn challenge_anonymous() {
+    test_response_model::<board::stream::events::Event>("challenge_anonymous");
     test_response_model::<board::stream::game::Event>("game_full_anonymous");
 }
 

--- a/tests/response_models.rs
+++ b/tests/response_models.rs
@@ -43,6 +43,11 @@ pub fn challenge_ai() {
 }
 
 #[test]
+pub fn challenge_anonymous() {
+    test_response_model::<board::stream::game::Event>("game_full_anonymous");
+}
+
+#[test]
 pub fn puzzle() {
     test_response_model::<puzzles::PuzzleAndGame>("puzzle");
 }


### PR DESCRIPTION
In games against anonymous players lichess returns `{}` for the player in `GameEventInfo`, by adding an Anonymous variant serde can correctly deserialise the json. For challenges from anonymous players lichess doesn't return a player at all.