### PR TITLE
Fix GetRequest to use user_id instead of game_id

### DIFF
--- a/src/model/games/export/by_user.rs
+++ b/src/model/games/export/by_user.rs
@@ -39,8 +39,8 @@ pub enum Sort {
 pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
-    pub fn new(game_id: &str, query: GetQuery) -> Self {
-        let path = format!("/api/games/user/{}", game_id);
+    pub fn new(user_id: &str, query: GetQuery) -> Self {
+        let path = format!("/api/games/user/{}", user_id);
         Self {
             path,
             query: Some(query),


### PR DESCRIPTION
### Description

This pull request updates the `GetRequest` struct for exporting games by user to use `user_id` instead of `game_id` in the API path. This correction aligns the endpoint with the intended API design for retrieving games associated by user.

### Changes Made

- Modified the `GetRequest::new` in `src/model/games/export/by_user.rs` to use `user_id` instead of `game_id`.