### PR TITLE
Fixed GameMoveAnalysis eval field

### DIFF
--- a/src/model/games/mod.rs
+++ b/src/model/games/mod.rs
@@ -119,7 +119,7 @@ pub struct Division {
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GameMoveAnalysis {
-    pub eval: Option<u32>,
+    pub eval: Option<i32>,
     pub mate: Option<u32>,
     pub best: Option<String>,
     pub variation: Option<String>,

--- a/tests/data/response/game_json.json
+++ b/tests/data/response/game_json.json
@@ -58,6 +58,15 @@
                 "name": "Inaccuracy",
                 "comment": "Inaccuracy. d5 was best."
             }
+        },
+        {
+            "eval": -37,
+            "best": "d3e4",
+            "variation": "Be4 Bxc3",
+            "judgment": {
+                "name": "Mistake",
+                "comment": "Mistake. Be4 was best."
+            }
         }
     ],
     "division": {


### PR DESCRIPTION
### Description
This pull request updates the GameMoveAnalysis struct. This change fixes the `eval` field, which can be also a negative number (when an advantage for black).

### Changes Made
* Modified the `GameMoveAnalysis.eval` field in src/model/games/mod.rs to `Option<i32>`.
* Added a negative eval test data to the test file `tests/data/response/game_json.json`.