### PR TITLE
Make Client methods parameters more intuitive

### DIFF
--- a/examples/lichess.rs
+++ b/examples/lichess.rs
@@ -111,8 +111,7 @@ impl PuzzleCommand {
     async fn run(self, lichess: Lichess) -> Result<()> {
         match self {
             PuzzleCommand::Daily => {
-                let request = daily::GetRequest::new();
-                let puzzle = lichess.get_daily_puzzle(request).await?;
+                let puzzle = lichess.get_daily_puzzle().await?;
                 println!("{puzzle:#?}");
                 Ok(())
             }
@@ -253,8 +252,7 @@ impl ExternalEngineCommand {
     async fn run(self, lichess: Lichess) -> Result<()> {
         match self {
             ExternalEngineCommand::List => {
-                let request = list::GetRequest::new();
-                let engines = lichess.list_external_engines(request).await?;
+                let engines = lichess.list_external_engines().await?;
                 println!("{:#?}", engines);
                 Ok(())
             }

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -3,26 +3,23 @@ use crate::error::Result;
 use crate::model::account::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn get_profile(&self, request: profile::GetRequest) -> Result<profile::Profile> {
-        self.get_single_model(request).await
+    pub async fn get_profile(&self) -> Result<profile::Profile> {
+        self.get_single_model(profile::GetRequest::new()).await
     }
 
-    pub async fn get_email_address(&self, request: email::GetRequest) -> Result<email::Email> {
-        self.get_single_model(request).await
+    pub async fn get_email_address(&self) -> Result<email::Email> {
+        self.get_single_model(email::GetRequest::new()).await
     }
 
-    pub async fn get_preferences(
-        &self,
-        request: preferences::GetRequest,
-    ) -> Result<preferences::UserPreferences> {
-        self.get_single_model(request).await
+    pub async fn get_preferences(&self) -> Result<preferences::UserPreferences> {
+        self.get_single_model(preferences::GetRequest::new()).await
     }
 
-    pub async fn get_kid_mode_status(&self, request: kid::GetRequest) -> Result<kid::KidMode> {
-        self.get_single_model(request).await
+    pub async fn get_kid_mode_status(&self) -> Result<kid::KidMode> {
+        self.get_single_model(kid::GetRequest::new()).await
     }
 
-    pub async fn set_kid_mode_status(&self, request: kid::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn set_kid_mode_status(&self, request: impl Into<kid::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 }

--- a/src/api/analysis.rs
+++ b/src/api/analysis.rs
@@ -5,8 +5,8 @@ use crate::model::analysis::*;
 impl LichessApi<reqwest::Client> {
     pub async fn get_cloud_evaluation(
         &self,
-        request: cloud::GetRequest,
+        request: impl Into<cloud::GetRequest>,
     ) -> Result<cloud::Evaluation> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 }

--- a/src/api/board.rs
+++ b/src/api/board.rs
@@ -5,63 +5,72 @@ use crate::error::Result;
 use crate::model::board::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn board_abort_game(&self, request: abort::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_abort_game(&self, request: impl Into<abort::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn board_berserk_game(&self, request: berserk::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_berserk_game(
+        &self,
+        request: impl Into<berserk::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
     pub async fn board_stream_game_chat(
         &self,
-        request: chat::GetRequest,
+        request: impl Into<chat::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<chat::ChatLine>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
-    pub async fn board_write_in_chat(&self, request: chat::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_write_in_chat(&self, request: impl Into<chat::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn board_claim_victory(&self, request: claim_victory::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_claim_victory(
+        &self,
+        request: impl Into<claim_victory::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn board_handle_draw(&self, request: draw::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_handle_draw(&self, request: impl Into<draw::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn board_make_move(&self, request: r#move::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_make_move(&self, request: impl Into<r#move::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn board_resign_game(&self, request: resign::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_resign_game(&self, request: impl Into<resign::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
     pub async fn board_create_a_seek(
         &self,
-        request: seek::PostRequest,
+        request: impl Into<seek::PostRequest>,
     ) -> Result<impl StreamExt<Item = Result<serde_json::Value>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn board_stream_incoming_events(
         &self,
-        request: stream::events::GetRequest,
+        request: impl Into<stream::events::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<stream::events::Event>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn board_stream_board_state(
         &self,
-        request: stream::game::GetRequest,
+        request: impl Into<stream::game::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<stream::game::Event>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
-    pub async fn board_handle_takeback(&self, request: takeback::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn board_handle_takeback(
+        &self,
+        request: impl Into<takeback::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 }

--- a/src/api/bot.rs
+++ b/src/api/bot.rs
@@ -6,55 +6,58 @@ use crate::model::bot::online::OnlineBot;
 use crate::model::bot::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn bot_abort_game(&self, request: abort::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn bot_abort_game(&self, request: impl Into<abort::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
     pub async fn bot_stream_game_chat(
         &self,
-        request: chat::GetRequest,
+        request: impl Into<chat::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<chat::ChatLine>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
-    pub async fn bot_write_in_chat(&self, request: chat::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn bot_write_in_chat(&self, request: impl Into<chat::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn bot_draw_game(&self, request: draw::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn bot_draw_game(&self, request: impl Into<draw::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn bot_make_move(&self, request: r#move::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn bot_make_move(&self, request: impl Into<r#move::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
     pub async fn bot_get_online(
         &self,
-        request: online::GetRequest,
+        request: impl Into<online::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<OnlineBot>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
-    pub async fn bot_resign_game(&self, request: resign::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn bot_resign_game(&self, request: impl Into<resign::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
     pub async fn bot_stream_incoming_events(
         &self,
-        request: stream::events::GetRequest,
+        request: impl Into<stream::events::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<stream::events::Event>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn bot_stream_board_state(
         &self,
-        request: stream::game::GetRequest,
+        request: impl Into<stream::game::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<stream::game::Event>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
-    pub async fn bot_upgrade_account(&self, request: upgrade::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn bot_upgrade_account(
+        &self,
+        request: impl Into<upgrade::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 }

--- a/src/api/challenges.rs
+++ b/src/api/challenges.rs
@@ -4,42 +4,54 @@ use crate::model::challenges::*;
 use crate::model::games::stream::moves::Move;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn list_challenges(&self, request: list::GetRequest) -> Result<list::Challenges> {
-        self.get_single_model(request).await
+    pub async fn list_challenges(&self) -> Result<list::Challenges> {
+        self.get_single_model(list::GetRequest::new()).await
     }
 
-    pub async fn create_challenge(&self, request: create::PostRequest) -> Result<ChallengeCreated> {
-        self.get_single_model(request).await
+    pub async fn create_challenge(
+        &self,
+        request: impl Into<create::PostRequest>,
+    ) -> Result<ChallengeCreated> {
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn accept_challenge(&self, request: accept::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn accept_challenge(&self, request: impl Into<accept::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn decline_challenge(&self, request: decline::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn decline_challenge(
+        &self,
+        request: impl Into<decline::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn cancel_challenge(&self, request: cancel::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn cancel_challenge(&self, request: impl Into<cancel::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn challenge_ai(&self, request: ai::PostRequest) -> Result<Move> {
-        self.get_single_model(request).await
+    pub async fn challenge_ai(&self, request: impl Into<ai::PostRequest>) -> Result<Move> {
+        self.get_single_model(request.into()).await
     }
 
     pub async fn create_open_challenge(
         &self,
-        request: open::PostRequest,
+        request: impl Into<open::PostRequest>,
     ) -> Result<ChallengeOpenJson> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn start_clocks(&self, request: start_clocks::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn start_clocks(
+        &self,
+        request: impl Into<start_clocks::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
-    pub async fn add_time_to_opponent_clock(&self, request: add_time::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn add_time_to_opponent_clock(
+        &self,
+        request: impl Into<add_time::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 }

--- a/src/api/external_engine.rs
+++ b/src/api/external_engine.rs
@@ -5,48 +5,51 @@ use crate::error::Result;
 use crate::model::external_engine::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn list_external_engines(
-        &self,
-        request: list::GetRequest,
-    ) -> Result<Vec<ExternalEngine>> {
-        self.get_single_model(request).await
+    pub async fn list_external_engines(&self) -> Result<Vec<ExternalEngine>> {
+        self.get_single_model(list::GetRequest::new()).await
     }
 
     pub async fn create_external_engine(
         &self,
-        request: create::PostRequest,
+        request: impl Into<create::PostRequest>,
     ) -> Result<ExternalEngine> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn get_external_engine(&self, request: id::GetRequest) -> Result<ExternalEngine> {
-        self.get_single_model(request).await
+    pub async fn get_external_engine(
+        &self,
+        request: impl Into<id::GetRequest>,
+    ) -> Result<ExternalEngine> {
+        self.get_single_model(request.into()).await
     }
 
     pub async fn update_external_engine(
         &self,
-        request: update::PutRequest,
+        request: impl Into<update::PutRequest>,
     ) -> Result<ExternalEngine> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn delete_external_engine(&self, request: delete::DeleteRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn delete_external_engine(
+        &self,
+        request: impl Into<delete::DeleteRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 
     /// This method currently returns a 503 error (Service Unavailable) from the Lichess API
     pub async fn analyse_with_external_engine(
         &self,
-        request: analyse::PostRequest,
+        request: impl Into<analyse::PostRequest>,
     ) -> Result<impl StreamExt<Item = Result<analyse::AnalysisResponse>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn acquire_analysis_request(
         &self,
-        request: acquire_analysis::PostRequest,
+        request: impl Into<acquire_analysis::PostRequest>,
     ) -> Result<Option<acquire_analysis::AcquireAnalysisResponse>> {
-        let mut stream = self.get_streamed_models(request).await?;
+        let mut stream = self.get_streamed_models(request.into()).await?;
         // The response is a stream of 0 or 1 items, so we can just take the first item
         Ok((stream.next().await).transpose()?)
     }

--- a/src/api/games.rs
+++ b/src/api/games.rs
@@ -5,67 +5,73 @@ use crate::error::Result;
 use crate::model::games::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn export_one_game(&self, request: export::one::GetRequest) -> Result<GameJson> {
-        self.get_single_model(request).await
+    pub async fn export_one_game(
+        &self,
+        request: impl Into<export::one::GetRequest>,
+    ) -> Result<GameJson> {
+        self.get_single_model(request.into()).await
     }
 
     pub async fn export_ongoing_game(
         &self,
-        request: export::ongoing::GetRequest,
+        request: impl Into<export::ongoing::GetRequest>,
     ) -> Result<GameJson> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
     pub async fn export_games_of_user(
         &self,
-        request: export::by_user::GetRequest,
+        request: impl Into<export::by_user::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<GameJson>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn export_games_by_ids(
         &self,
-        request: export::by_ids::PostRequest,
+        request: impl Into<export::by_ids::PostRequest>,
     ) -> Result<impl StreamExt<Item = Result<GameJson>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn stream_games_of_users(
         &self,
-        request: stream::by_users::PostRequest,
+        request: impl Into<stream::by_users::PostRequest>,
     ) -> Result<impl StreamExt<Item = Result<GameStream>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn stream_games_by_ids(
         &self,
-        request: stream::by_ids::PostRequest,
+        request: impl Into<stream::by_ids::PostRequest>,
     ) -> Result<impl StreamExt<Item = Result<GameStream>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn add_game_ids_to_stream(
         &self,
-        request: stream::add_ids::PostRequest,
+        request: impl Into<stream::add_ids::PostRequest>,
     ) -> Result<bool> {
-        self.get_ok(request).await
+        self.get_ok(request.into()).await
     }
 
     pub async fn get_my_ongoing_games(
         &self,
-        request: ongoing::GetRequest,
+        request: impl Into<ongoing::GetRequest>,
     ) -> Result<ongoing::Games> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
     pub async fn stream_game_moves(
         &self,
-        request: stream::moves::GetRequest,
+        request: impl Into<stream::moves::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<stream::moves::Move>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
-    pub async fn import_game(&self, request: import::PostRequest) -> Result<import::ImportData> {
-        self.get_single_model(request).await
+    pub async fn import_game(
+        &self,
+        request: impl Into<import::PostRequest>,
+    ) -> Result<import::ImportData> {
+        self.get_single_model(request.into()).await
     }
 }

--- a/src/api/messaging.rs
+++ b/src/api/messaging.rs
@@ -3,7 +3,7 @@ use crate::error::Result;
 use crate::model::messaging::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn send_message(&self, request: inbox::PostRequest) -> Result<bool> {
-        self.get_ok(request).await
+    pub async fn send_message(&self, request: impl Into<inbox::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
     }
 }

--- a/src/api/openings.rs
+++ b/src/api/openings.rs
@@ -7,29 +7,29 @@ use crate::model::openings::*;
 impl LichessApi<reqwest::Client> {
     pub async fn openings_masters(
         &self,
-        request: masters::GetRequest,
+        request: impl Into<masters::GetRequest>,
     ) -> Result<OpeningExplorerJson> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
     pub async fn openings_lichess(
         &self,
-        request: lichess::GetRequest,
+        request: impl Into<lichess::GetRequest>,
     ) -> Result<OpeningExplorerJson> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
     pub async fn openings_player(
         &self,
-        request: player::GetRequest,
+        request: impl Into<player::GetRequest>,
     ) -> Result<OpeningExplorerJson> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
     pub async fn openings_otb(
         &self,
-        request: otb::GetRequest,
+        request: impl Into<otb::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<String>>> {
-        self.get_pgn(request).await
+        self.get_pgn(request.into()).await
     }
 }

--- a/src/api/puzzles.rs
+++ b/src/api/puzzles.rs
@@ -5,36 +5,39 @@ use crate::error::Result;
 use crate::model::puzzles::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn get_daily_puzzle(&self, request: daily::GetRequest) -> Result<daily::Puzzle> {
-        self.get_single_model(request).await
+    pub async fn get_daily_puzzle(&self) -> Result<daily::Puzzle> {
+        self.get_single_model(daily::GetRequest::new()).await
     }
 
-    pub async fn get_puzzle(&self, request: id::GetRequest) -> Result<id::Puzzle> {
-        self.get_single_model(request).await
+    pub async fn get_puzzle(&self, request: impl Into<id::GetRequest>) -> Result<id::Puzzle> {
+        self.get_single_model(request.into()).await
     }
 
     pub async fn get_puzzle_activity(
         &self,
-        request: activity::GetRequest,
+        request: impl Into<activity::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<activity::Round>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn get_puzzle_dashboard(
         &self,
-        request: dashboard::GetRequest,
+        request: impl Into<dashboard::GetRequest>,
     ) -> Result<dashboard::Dashboard> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
     pub async fn get_puzzle_storm_dashboard(
         &self,
-        request: storm_dashboard::GetRequest,
+        request: impl Into<storm_dashboard::GetRequest>,
     ) -> Result<storm_dashboard::Dashboard> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn make_puzzle_race(&self, request: race::PostRequest) -> Result<race::Race> {
-        self.get_single_model(request).await
+    pub async fn make_puzzle_race(
+        &self,
+        request: impl Into<race::PostRequest>,
+    ) -> Result<race::Race> {
+        self.get_single_model(request.into()).await
     }
 }

--- a/src/api/studies.rs
+++ b/src/api/studies.rs
@@ -5,8 +5,8 @@ use crate::model::studies::import_pgn_into_study::{PostRequest, StudyImportPgnCh
 impl LichessApi<reqwest::Client> {
     pub async fn import_pgn_into_study(
         &self,
-        request: PostRequest,
+        request: impl Into<PostRequest>,
     ) -> Result<StudyImportPgnChapters> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 }

--- a/src/api/tablebase.rs
+++ b/src/api/tablebase.rs
@@ -3,15 +3,24 @@ use crate::error::Result;
 use crate::model::tablebase::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn lookup_antichess(&self, request: antichess::GetRequest) -> Result<TablebaseJson> {
-        self.get_single_model(request).await
+    pub async fn lookup_antichess(
+        &self,
+        request: impl Into<antichess::GetRequest>,
+    ) -> Result<TablebaseJson> {
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn lookup_atomic(&self, request: atomic::GetRequest) -> Result<TablebaseJson> {
-        self.get_single_model(request).await
+    pub async fn lookup_atomic(
+        &self,
+        request: impl Into<atomic::GetRequest>,
+    ) -> Result<TablebaseJson> {
+        self.get_single_model(request.into()).await
     }
 
-    pub async fn lookup_standard(&self, request: standard::GetRequest) -> Result<TablebaseJson> {
-        self.get_single_model(request).await
+    pub async fn lookup_standard(
+        &self,
+        request: impl Into<standard::GetRequest>,
+    ) -> Result<TablebaseJson> {
+        self.get_single_model(request.into()).await
     }
 }

--- a/src/api/tv.rs
+++ b/src/api/tv.rs
@@ -6,28 +6,26 @@ use crate::model::games::GameJson;
 use crate::model::tv::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn tv_channels(&self, request: channels::GetRequest) -> Result<Channels> {
-        self.get_single_model(request).await
+    pub async fn tv_channels(&self) -> Result<Channels> {
+        self.get_single_model(channels::GetRequest::new()).await
     }
 
-    pub async fn tv_stream_current(
-        &self,
-        request: stream::current::GetRequest,
-    ) -> Result<impl StreamExt<Item = Result<stream::Event>>> {
-        self.get_streamed_models(request).await
+    pub async fn tv_stream_current(&self) -> Result<impl StreamExt<Item = Result<stream::Event>>> {
+        self.get_streamed_models(stream::current::GetRequest::new())
+            .await
     }
 
     pub async fn tv_stream_channel_current(
         &self,
-        request: stream::channel::GetRequest,
+        request: impl Into<stream::channel::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<stream::Event>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 
     pub async fn tv_channel_games(
         &self,
-        request: games::GetRequest,
+        request: impl Into<games::GetRequest>,
     ) -> Result<impl StreamExt<Item = Result<GameJson>>> {
-        self.get_streamed_models(request).await
+        self.get_streamed_models(request.into()).await
     }
 }

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -3,14 +3,17 @@ use crate::error::Result;
 use crate::model::users::*;
 
 impl LichessApi<reqwest::Client> {
-    pub async fn get_public_user_data(&self, request: public::GetRequest) -> Result<UserExtended> {
-        self.get_single_model(request).await
+    pub async fn get_public_user_data(
+        &self,
+        request: impl Into<public::GetRequest>,
+    ) -> Result<UserExtended> {
+        self.get_single_model(request.into()).await
     }
 
     pub async fn get_status_of_users(
         &self,
-        request: status::GetRequest,
+        request: impl Into<status::GetRequest>,
     ) -> Result<Vec<status::User>> {
-        self.get_single_model(request).await
+        self.get_single_model(request.into()).await
     }
 }

--- a/src/model/account/email.rs
+++ b/src/model/account/email.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/account/email".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/account/email", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/account/kid.rs
+++ b/src/model/account/kid.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/account/kid".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/account/kid", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -23,12 +26,13 @@ pub type PostRequest = crate::model::Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(on: bool) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/account/kid".to_string(),
-            query: Some(PostQuery { v: on }),
-            ..Default::default()
-        }
+        Self::get("/api/account/kid", PostQuery { v: on }, None)
+    }
+}
+
+impl From<bool> for PostRequest {
+    fn from(on: bool) -> Self {
+        Self::new(on)
     }
 }
 

--- a/src/model/account/preferences.rs
+++ b/src/model/account/preferences.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/account/preferences".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/account/preferences", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/account/profile.rs
+++ b/src/model/account/profile.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/account".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/account", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/analysis/cloud.rs
+++ b/src/model/analysis/cloud.rs
@@ -16,11 +16,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(query: GetQuery) -> Self {
-        Self {
-            path: "/api/cloud-eval".to_string(),
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get("/api/cloud-eval", query, None)
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
     }
 }
 

--- a/src/model/board/abort.rs
+++ b/src/model/board/abort.rs
@@ -8,11 +8,12 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/board/game/{}/abort", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        Self::post(format!("/api/board/game/{game_id}/abort"), None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/board/berserk.rs
+++ b/src/model/board/berserk.rs
@@ -8,11 +8,13 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/board/game/{}/berserk", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/berserk");
+        Self::post(path, None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/board/chat.rs
+++ b/src/model/board/chat.rs
@@ -8,11 +8,13 @@ pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/board/game/{}/chat", game_id);
-        Self {
-            path,
-            ..Default::default()
-        }
+        Self::get(format!("/api/board/game/{game_id}/chat"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 
@@ -33,13 +35,8 @@ impl PostRequest {
             room,
             text: message.to_string(),
         };
-        let path = format!("/api/board/game/{}/chat", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            body: Body::Form(message),
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/chat");
+        Self::post(path, None, Body::Form(message), None)
     }
 }
 

--- a/src/model/board/claim_victory.rs
+++ b/src/model/board/claim_victory.rs
@@ -8,11 +8,13 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/board/game/{}/claim-victory", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/claim-victory");
+        Self::post(path, None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/board/draw.rs
+++ b/src/model/board/draw.rs
@@ -9,11 +9,7 @@ pub type PostRequest = Request<PostQuery>;
 impl PostRequest {
     pub fn new(game_id: &str, accept: bool) -> Self {
         let accept = if accept { "yes" } else { "no" };
-        let path = format!("/api/board/game/{}/draw/{}", game_id, accept);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/draw/{accept}");
+        Self::post(path, None, None, None)
     }
 }

--- a/src/model/board/move.rs
+++ b/src/model/board/move.rs
@@ -10,12 +10,7 @@ pub type PostRequest = crate::model::Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str, r#move: &str, offering_draw: bool) -> Self {
-        let path = format!("/api/board/game/{}/move/{}", game_id, r#move);
-        Self {
-            method: http::Method::POST,
-            path,
-            query: Some(PostQuery { offering_draw }),
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/move/{move}");
+        Self::post(path, PostQuery { offering_draw }, None, None)
     }
 }

--- a/src/model/board/resign.rs
+++ b/src/model/board/resign.rs
@@ -8,11 +8,13 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/board/game/{}/resign", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/resign");
+        Self::post(path, None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/board/seek.rs
+++ b/src/model/board/seek.rs
@@ -37,14 +37,14 @@ impl Default for PostQuery {
 pub type PostRequest = crate::model::Request<PostQuery>;
 
 impl PostRequest {
-    pub fn new() -> Self {
-        PostQuery::default().into()
+    pub fn new(query: PostQuery) -> Self {
+        Self::post("/api/board/seek", query, None, None)
     }
 }
 
 impl From<PostQuery> for PostRequest {
     fn from(query: PostQuery) -> Self {
-        Self::post("/api/board/seek", query, None, None)
+        Self::new(query)
     }
 }
 

--- a/src/model/board/seek.rs
+++ b/src/model/board/seek.rs
@@ -38,10 +38,18 @@ pub type PostRequest = crate::model::Request<PostQuery>;
 
 impl PostRequest {
     pub fn new() -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/board/seek".to_string(),
-            ..Default::default()
-        }
+        PostQuery::default().into()
+    }
+}
+
+impl From<PostQuery> for PostRequest {
+    fn from(query: PostQuery) -> Self {
+        Self::post("/api/board/seek", query, None, None)
+    }
+}
+
+impl Default for PostRequest {
+    fn default() -> Self {
+        PostQuery::default().into()
     }
 }

--- a/src/model/board/stream/events.rs
+++ b/src/model/board/stream/events.rs
@@ -10,10 +10,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/stream/event".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/stream/event", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/board/stream/game.rs
+++ b/src/model/board/stream/game.rs
@@ -9,11 +9,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/board/game/stream/{}", game_id);
-        Self {
-            path,
-            ..Default::default()
-        }
+        Self::get(format!("/api/board/game/stream/{game_id}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 

--- a/src/model/board/takeback.rs
+++ b/src/model/board/takeback.rs
@@ -9,11 +9,7 @@ pub type PostRequest = Request<PostQuery>;
 impl PostRequest {
     pub fn new(game_id: &str, accept: bool) -> Self {
         let accept = if accept { "yes" } else { "no" };
-        let path = format!("/api/board/game/{}/takeback/{}", game_id, accept);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/board/game/{game_id}/takeback/{accept}");
+        Self::post(path, None, None, None)
     }
 }

--- a/src/model/bot/abort.rs
+++ b/src/model/bot/abort.rs
@@ -8,11 +8,12 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/bot/game/{}/abort", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        Self::post(format!("/api/bot/game/{game_id}/abort"), None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/bot/chat.rs
+++ b/src/model/bot/chat.rs
@@ -9,11 +9,13 @@ pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/bot/game/{}/chat", game_id);
-        Self {
-            path,
-            ..Default::default()
-        }
+        Self::get(format!("/api/bot/game/{game_id}/chat"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 
@@ -28,13 +30,8 @@ impl PostRequest {
             room,
             text: message.to_string(),
         };
-        let path = format!("/api/bot/game/{}/chat", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            body: Body::Form(message),
-            ..Default::default()
-        }
+        let path = format!("/api/bot/game/{game_id}/chat");
+        Self::post(path, None, Body::Form(message), None)
     }
 }
 

--- a/src/model/bot/draw.rs
+++ b/src/model/bot/draw.rs
@@ -9,11 +9,7 @@ pub type PostRequest = Request<PostQuery>;
 impl PostRequest {
     pub fn new(game_id: &str, accept: bool) -> Self {
         let accept = if accept { "yes" } else { "no" };
-        let path = format!("/api/bot/game/{}/draw/{}", game_id, accept);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/bot/game/{game_id}/draw/{accept}");
+        Self::post(path, None, None, None)
     }
 }

--- a/src/model/bot/move.rs
+++ b/src/model/bot/move.rs
@@ -10,12 +10,7 @@ pub type PostRequest = crate::model::Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str, r#move: &str, offering_draw: bool) -> Self {
-        let path = format!("/api/bot/game/{}/move/{}", game_id, r#move);
-        Self {
-            method: http::Method::POST,
-            path,
-            query: Some(PostQuery { offering_draw }),
-            ..Default::default()
-        }
+        let path = format!("/api/bot/game/{game_id}/move/{move}");
+        Self::post(path, PostQuery { offering_draw }, None, None)
     }
 }

--- a/src/model/bot/online.rs
+++ b/src/model/bot/online.rs
@@ -10,11 +10,13 @@ pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(bot_count: u32) -> Self {
-        Self {
-            path: "/api/bot/online".to_string(),
-            query: Some(GetQuery { nb: bot_count }),
-            ..Default::default()
-        }
+        Self::get("/api/bot/online", GetQuery { nb: bot_count }, None)
+    }
+}
+
+impl From<u32> for GetRequest {
+    fn from(bot_count: u32) -> Self {
+        Self::new(bot_count)
     }
 }
 

--- a/src/model/bot/resign.rs
+++ b/src/model/bot/resign.rs
@@ -8,11 +8,12 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/bot/game/{}/resign", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        Self::post(format!("/api/bot/game/{game_id}/resign"), None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/bot/stream/game.rs
+++ b/src/model/bot/stream/game.rs
@@ -7,11 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(game_id: &str) -> Self {
-        let path = format!("/api/bot/game/stream/{}", game_id);
-        Self {
-            path,
-            ..Default::default()
-        }
+        Self::get(format!("/api/bot/game/stream/{game_id}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 

--- a/src/model/bot/upgrade.rs
+++ b/src/model/bot/upgrade.rs
@@ -8,10 +8,12 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new() -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/bot/account/upgrade".to_string(),
-            ..Default::default()
-        }
+        Self::post("/api/bot/account/upgrade", None, None, None)
+    }
+}
+
+impl Default for PostRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/model/challenges/accept.rs
+++ b/src/model/challenges/accept.rs
@@ -7,12 +7,14 @@ pub struct PostQuery;
 pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
-    pub fn new(challenge_id: String) -> Self {
-        let path = format!("/api/challenge/{}/accept", challenge_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+    pub fn new(challenge_id: &str) -> Self {
+        let path = format!("/api/challenge/{challenge_id}/accept");
+        Self::post(path, None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/challenges/add_time.rs
+++ b/src/model/challenges/add_time.rs
@@ -8,11 +8,7 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: String, seconds: u32) -> Self {
-        let path = format!("/api/round/{}/add-time/{}", game_id, seconds);
-        Self {
-            method: http::Method::POST,
-            path,
-            ..Default::default()
-        }
+        let path = format!("/api/round/{game_id}/add-time/{seconds}");
+        Self::post(path, None, None, None)
     }
 }

--- a/src/model/challenges/ai.rs
+++ b/src/model/challenges/ai.rs
@@ -9,11 +9,12 @@ pub type PostRequest = Request<PostQuery, AIChallenge>;
 
 impl PostRequest {
     pub fn new(challenge: AIChallenge) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/challenge/ai".to_string(),
-            body: Body::Form(challenge),
-            ..Default::default()
-        }
+        Self::post("/api/challenge/ai", None, Body::Form(challenge), None)
+    }
+}
+
+impl From<AIChallenge> for PostRequest {
+    fn from(challenge: AIChallenge) -> Self {
+        Self::new(challenge)
     }
 }

--- a/src/model/challenges/cancel.rs
+++ b/src/model/challenges/cancel.rs
@@ -11,12 +11,14 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(challenge_id: String, opponent_token: Option<String>) -> Self {
-        let path = format!("/api/challenge/{}/cancel", challenge_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            query: opponent_token.map(|t| PostQuery { opponent_token: t }),
-            ..Default::default()
-        }
+        let path = format!("/api/challenge/{challenge_id}/cancel");
+        let query = opponent_token.map(|t| PostQuery { opponent_token: t });
+        Self::post(path, query, None, None)
+    }
+}
+
+impl<S: Into<String>> From<S> for PostRequest {
+    fn from(challenge_id: S) -> Self {
+        Self::new(challenge_id.into(), None)
     }
 }

--- a/src/model/challenges/create.rs
+++ b/src/model/challenges/create.rs
@@ -10,12 +10,7 @@ pub type PostRequest = Request<PostQuery, CreateChallenge>;
 
 impl PostRequest {
     pub fn new(username: &str, challenge: CreateChallenge) -> Self {
-        let path = format!("/api/challenge/{}", username);
-        Self {
-            method: http::Method::POST,
-            path,
-            body: Body::Form(challenge),
-            ..Default::default()
-        }
+        let path = format!("/api/challenge/{username}");
+        Self::post(path, None, Body::Form(challenge), None)
     }
 }

--- a/src/model/challenges/decline.rs
+++ b/src/model/challenges/decline.rs
@@ -30,12 +30,7 @@ pub type PostRequest = Request<PostQuery, DeclineReason>;
 
 impl PostRequest {
     pub fn new(challenge_id: String, reason: Reason) -> Self {
-        let path = format!("/api/challenge/{}/decline", challenge_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            body: Body::Form(DeclineReason { reason }),
-            ..Default::default()
-        }
+        let path = format!("/api/challenge/{challenge_id}/decline");
+        Self::post(path, None, Body::Form(DeclineReason { reason }), None)
     }
 }

--- a/src/model/challenges/list.rs
+++ b/src/model/challenges/list.rs
@@ -9,10 +9,13 @@ pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/challenge".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/challenge", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/challenges/open.rs
+++ b/src/model/challenges/open.rs
@@ -9,11 +9,12 @@ pub type PostRequest = Request<PostQuery, OpenChallenge>;
 
 impl PostRequest {
     pub fn new(challenge: OpenChallenge) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/challenge/open".to_string(),
-            body: Body::Form(challenge),
-            ..Default::default()
-        }
+        Self::post("/api/challenge/open", None, Body::Form(challenge), None)
+    }
+}
+
+impl From<OpenChallenge> for PostRequest {
+    fn from(challenge: OpenChallenge) -> Self {
+        Self::new(challenge)
     }
 }

--- a/src/model/challenges/start_clocks.rs
+++ b/src/model/challenges/start_clocks.rs
@@ -11,12 +11,7 @@ pub type PostRequest = Request<PostQuery>;
 
 impl PostRequest {
     pub fn new(game_id: String, token1: String, token2: String) -> Self {
-        let path = format!("/api/challenge/{}/start-clocks", game_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            query: Some(PostQuery { token1, token2 }),
-            ..Default::default()
-        }
+        let path = format!("/api/challenge/{game_id}/start-clocks");
+        Self::post(path, PostQuery { token1, token2 }, None, None)
     }
 }

--- a/src/model/external_engine/create.rs
+++ b/src/model/external_engine/create.rs
@@ -10,12 +10,13 @@ pub type PostRequest = Request<PostQuery, CreateExternalEngine>;
 
 impl PostRequest {
     pub fn new(engine: CreateExternalEngine) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/external-engine".to_string(),
-            body: Body::Json(engine),
-            ..Default::default()
-        }
+        Self::post("/api/external-engine", None, Body::Json(engine), None)
+    }
+}
+
+impl From<CreateExternalEngine> for PostRequest {
+    fn from(engine: CreateExternalEngine) -> Self {
+        Self::new(engine)
     }
 }
 

--- a/src/model/external_engine/delete.rs
+++ b/src/model/external_engine/delete.rs
@@ -9,10 +9,12 @@ pub type DeleteRequest = Request<DeleteQuery>;
 
 impl DeleteRequest {
     pub fn new(id: &str) -> Self {
-        Self {
-            method: http::Method::DELETE,
-            path: format!("/api/external-engine/{}", id),
-            ..Default::default()
-        }
+        Self::delete(format!("/api/external-engine/{id}"), None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for DeleteRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }

--- a/src/model/external_engine/id.rs
+++ b/src/model/external_engine/id.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(id: &str) -> Self {
-        Self {
-            path: format!("/api/external-engine/{}", id),
-            ..Default::default()
-        }
+        Self::get(format!("/api/external-engine/{id}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 

--- a/src/model/external_engine/list.rs
+++ b/src/model/external_engine/list.rs
@@ -8,9 +8,12 @@ pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/external-engine".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/external-engine", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/model/external_engine/update.rs
+++ b/src/model/external_engine/update.rs
@@ -11,11 +11,7 @@ pub type PutRequest = Request<PutQuery, UpdateExternalEngine>;
 
 impl PutRequest {
     pub fn new(id: &str, engine: UpdateExternalEngine) -> Self {
-        Self {
-            method: http::Method::PUT,
-            path: format!("/api/external-engine/{}", id),
-            body: Body::Json(engine),
-            ..Default::default()
-        }
+        let path = format!("/api/external-engine/{id}");
+        Self::put(path, None, Body::Json(engine), None)
     }
 }

--- a/src/model/games/export/by_ids.rs
+++ b/src/model/games/export/by_ids.rs
@@ -12,12 +12,11 @@ pub type PostRequest = crate::model::Request<PostQuery, String>;
 
 impl PostRequest {
     pub fn new(game_ids: Vec<String>, query: PostQuery) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/games/export/_ids".to_string(),
-            query: Some(query),
-            body: Body::PlainText(game_ids.join(",")),
-            ..Default::default()
-        }
+        Self::post(
+            "/api/games/export/_ids",
+            query,
+            Body::PlainText(game_ids.join(",")),
+            None,
+        )
     }
 }

--- a/src/model/games/export/by_user.rs
+++ b/src/model/games/export/by_user.rs
@@ -40,11 +40,6 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(username: &str, query: GetQuery) -> Self {
-        let path = format!("/api/games/user/{}", username);
-        Self {
-            path,
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get(format!("/api/games/user/{username}"), query, None)
     }
 }

--- a/src/model/games/export/one.rs
+++ b/src/model/games/export/one.rs
@@ -11,11 +11,6 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(game_id: &str, query: GetQuery) -> Self {
-        let path = format!("/game/export/{}", game_id);
-        Self {
-            path,
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get(format!("/game/export/{game_id}"), query, None)
     }
 }

--- a/src/model/games/export/ongoing.rs
+++ b/src/model/games/export/ongoing.rs
@@ -11,11 +11,6 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(username: &str, query: GetQuery) -> Self {
-        let path = format!("/api/user/{}/current-game", username);
-        Self {
-            path,
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get(format!("/api/user/{username}/current-game"), query, None)
     }
 }

--- a/src/model/games/import.rs
+++ b/src/model/games/import.rs
@@ -13,12 +13,13 @@ pub type PostRequest = crate::model::Request<PostQuery, Game>;
 
 impl PostRequest {
     pub fn new(pgn: String) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/import".to_string(),
-            body: Body::Form(Game { pgn }),
-            ..Default::default()
-        }
+        Self::post("/api/import", None, Body::Form(Game { pgn }), None)
+    }
+}
+
+impl<S: Into<String>> From<S> for PostRequest {
+    fn from(pgn: S) -> Self {
+        Self::new(pgn.into())
     }
 }
 

--- a/src/model/games/ongoing.rs
+++ b/src/model/games/ongoing.rs
@@ -10,11 +10,19 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(max_games: u8) -> Self {
-        Self {
-            path: "/api/account/playing".to_string(),
-            query: Some(GetQuery { max_games }),
-            ..Default::default()
-        }
+        Self::get("/api/account/playing", GetQuery { max_games }, None)
+    }
+}
+
+impl From<u8> for GetRequest {
+    fn from(max_games: u8) -> Self {
+        Self::new(max_games)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new(9)
     }
 }
 

--- a/src/model/games/stream/add_ids.rs
+++ b/src/model/games/stream/add_ids.rs
@@ -9,11 +9,6 @@ pub type PostRequest = crate::model::Request<PostQuery, Vec<String>>;
 impl PostRequest {
     pub fn new(stream_id: &str, game_ids: Vec<String>) -> Self {
         let path = format!("/api/stream/games/{}/add", stream_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            body: Body::PlainText(game_ids.join(",")),
-            ..Default::default()
-        }
+        Self::post(path, None, Body::PlainText(game_ids.join(",")), None)
     }
 }

--- a/src/model/games/stream/by_ids.rs
+++ b/src/model/games/stream/by_ids.rs
@@ -8,12 +8,7 @@ pub type PostRequest = crate::model::Request<PostQuery, Vec<String>>;
 
 impl PostRequest {
     pub fn new(stream_id: &str, game_ids: Vec<String>) -> Self {
-        let path = format!("/api/stream/games/{}", stream_id);
-        Self {
-            method: http::Method::POST,
-            path,
-            body: Body::PlainText(game_ids.join(",")),
-            ..Default::default()
-        }
+        let path = format!("/api/stream/games/{stream_id}");
+        Self::post(path, None, Body::PlainText(game_ids.join(",")), None)
     }
 }

--- a/src/model/games/stream/by_users.rs
+++ b/src/model/games/stream/by_users.rs
@@ -10,12 +10,11 @@ pub type PostRequest = crate::model::Request<PostQuery, Vec<String>>;
 
 impl PostRequest {
     pub fn new(user_ids: Vec<String>, with_current_games: bool) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/stream/games-by-users".to_string(),
-            query: Some(PostQuery { with_current_games }),
-            body: Body::PlainText(user_ids.join(",")),
-            ..Default::default()
-        }
+        Self::post(
+            "/api/stream/games-by-users",
+            PostQuery { with_current_games },
+            Body::PlainText(user_ids.join(",")),
+            None,
+        )
     }
 }

--- a/src/model/games/stream/moves.rs
+++ b/src/model/games/stream/moves.rs
@@ -10,11 +10,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(id: &str) -> Self {
-        let path = format!("/api/stream/game/{}", id);
-        Self {
-            path,
-            ..Default::default()
-        }
+        Self::get(format!("/api/stream/game/{id}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 

--- a/src/model/messaging/inbox.rs
+++ b/src/model/messaging/inbox.rs
@@ -16,11 +16,12 @@ impl PostRequest {
         let message = Message {
             text: message.to_string(),
         };
-        Self {
-            method: http::Method::POST,
-            path: format!("/inbox/{}", username).to_string(),
-            body: Body::Form(message),
-            ..Default::default()
-        }
+
+        Self::post(
+            format!("/inbox/{username}"),
+            None,
+            Body::Form(message),
+            None,
+        )
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -94,19 +94,60 @@ where
     pub(crate) body: Body<B>,
 }
 
-impl<Q, B> Default for Request<Q, B>
+impl<Q, B> Request<Q, B>
 where
     Q: QueryBounds + Default,
     B: BodyBounds,
 {
-    fn default() -> Self {
+    pub(crate) fn create(
+        path: impl Into<String>,
+        query: impl Into<Option<Q>>,
+        body: impl Into<Option<Body<B>>>,
+        domain: impl Into<Option<Domain>>,
+        method: http::Method,
+    ) -> Self {
         Self {
-            domain: Domain::default(),
-            method: http::Method::default(),
-            path: "/".to_string(),
-            query: None,
-            body: Body::Empty,
+            domain: domain.into().unwrap_or_default(),
+            method,
+            path: path.into(),
+            query: query.into(),
+            body: body.into().unwrap_or(Body::Empty),
         }
+    }
+
+    pub(crate) fn get(
+        path: impl Into<String>,
+        query: impl Into<Option<Q>>,
+        domain: impl Into<Option<Domain>>,
+    ) -> Self {
+        Self::create(path, query, None, domain, http::Method::GET)
+    }
+
+    pub(crate) fn post(
+        path: impl Into<String>,
+        query: impl Into<Option<Q>>,
+        body: impl Into<Option<Body<B>>>,
+        domain: impl Into<Option<Domain>>,
+    ) -> Self {
+        Self::create(path, query, body, domain, http::Method::POST)
+    }
+
+    pub(crate) fn put(
+        path: impl Into<String>,
+        query: impl Into<Option<Q>>,
+        body: impl Into<Option<Body<B>>>,
+        domain: impl Into<Option<Domain>>,
+    ) -> Self {
+        Self::create(path, query, body, domain, http::Method::PUT)
+    }
+
+    pub(crate) fn delete(
+        path: impl Into<String>,
+        query: impl Into<Option<Q>>,
+        body: impl Into<Option<Body<B>>>,
+        domain: Option<Domain>,
+    ) -> Self {
+        Self::create(path, query, body, domain, http::Method::DELETE)
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -26,18 +26,13 @@ impl<Q: Serialize + Default> QueryBounds for Q {}
 pub trait ModelBounds: DeserializeOwned {}
 impl<M: DeserializeOwned> ModelBounds for M {}
 
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub enum Body<B: BodyBounds> {
     Form(B),
     Json(B),
     PlainText(String),
+    #[default]
     Empty,
-}
-
-impl Default for Body<()> {
-    fn default() -> Self {
-        Body::Empty
-    }
 }
 
 impl<B: BodyBounds> Body<B> {
@@ -111,7 +106,7 @@ where
             method,
             path: path.into(),
             query: query.into(),
-            body: body.into().unwrap_or(Body::Empty),
+            body: body.into().unwrap_or_default(),
         }
     }
 

--- a/src/model/openings/lichess.rs
+++ b/src/model/openings/lichess.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::model::VariantKey;
+use crate::model::{Domain, Request, VariantKey};
 
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
@@ -18,15 +18,16 @@ pub struct GetQuery {
     pub history: Option<bool>,
 }
 
-pub type GetRequest = crate::model::Request<GetQuery>;
+pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(query: GetQuery) -> Self {
-        Self {
-            domain: crate::model::Domain::Explorer,
-            path: "/lichess".to_string(),
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get("/lichess", query, Domain::Explorer)
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
     }
 }

--- a/src/model/openings/masters.rs
+++ b/src/model/openings/masters.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::model::{Domain, Request};
+
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
 pub struct GetQuery {
@@ -11,15 +13,16 @@ pub struct GetQuery {
     pub top_games: Option<u32>,
 }
 
-pub type GetRequest = crate::model::Request<GetQuery>;
+pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(query: GetQuery) -> Self {
-        Self {
-            domain: crate::model::Domain::Explorer,
-            path: "/masters".to_string(),
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get("/masters", query, Domain::Explorer)
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
     }
 }

--- a/src/model/openings/otb.rs
+++ b/src/model/openings/otb.rs
@@ -1,22 +1,28 @@
 use serde::{Deserialize, Serialize};
 
+use crate::model::{Domain, Request};
+
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
 pub struct GetQuery {
     game_id: String,
 }
 
-pub type GetRequest = crate::model::Request<GetQuery>;
+pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
-    pub fn new(game_id: &str) -> Self {
-        Self {
-            domain: crate::model::Domain::Explorer,
-            path: format!("/masters/pgn/{}", game_id),
-            query: Some(GetQuery {
-                game_id: game_id.to_string(),
-            }),
-            ..Default::default()
-        }
+    pub fn new(game_id: impl Into<String>) -> Self {
+        let game_id = game_id.into();
+        Self::get(
+            format!("/masters/pgn/{game_id}"),
+            GetQuery { game_id },
+            Domain::Explorer,
+        )
+    }
+}
+
+impl<S: Into<String>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s)
     }
 }

--- a/src/model/openings/player.rs
+++ b/src/model/openings/player.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::model::{Color, VariantKey};
+use crate::model::{Color, Domain, VariantKey};
 
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
@@ -22,11 +22,12 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(query: GetQuery) -> Self {
-        Self {
-            domain: crate::model::Domain::Explorer,
-            path: "/player".to_string(),
-            query: Some(query),
-            ..Default::default()
-        }
+        Self::get("/player", Some(query), Some(Domain::Explorer))
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
     }
 }

--- a/src/model/puzzles/activity.rs
+++ b/src/model/puzzles/activity.rs
@@ -9,11 +9,20 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(max_rounds: Option<u32>) -> Self {
-        Self {
-            path: "/api/puzzle/activity".to_string(),
-            query: max_rounds.map(|max| GetQuery { max }),
-            ..Default::default()
-        }
+        let query = max_rounds.map(|max| GetQuery { max });
+        Self::get("/api/puzzle/activity", query, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl From<u32> for GetRequest {
+    fn from(max: u32) -> Self {
+        Self::new(Some(max))
     }
 }
 

--- a/src/model/puzzles/daily.rs
+++ b/src/model/puzzles/daily.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/puzzle/daily".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/puzzle/daily", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/puzzles/dashboard.rs
+++ b/src/model/puzzles/dashboard.rs
@@ -9,10 +9,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(days: u32) -> Self {
-        Self {
-            path: format!("/api/puzzle/dashboard/{}", days),
-            ..Default::default()
-        }
+        Self::get(format!("/api/puzzle/dashboard/{days}"), None, None)
+    }
+}
+
+impl From<u32> for GetRequest {
+    fn from(days: u32) -> Self {
+        Self::new(days)
     }
 }
 

--- a/src/model/puzzles/id.rs
+++ b/src/model/puzzles/id.rs
@@ -7,10 +7,13 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(id: &str) -> Self {
-        Self {
-            path: format!("/api/puzzle/{}", id),
-            ..Default::default()
-        }
+        Self::get(format!("/api/puzzle/{id}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref())
     }
 }
 

--- a/src/model/puzzles/race.rs
+++ b/src/model/puzzles/race.rs
@@ -7,11 +7,13 @@ pub type PostRequest = crate::model::Request<PostQuery>;
 
 impl PostRequest {
     pub fn new() -> Self {
-        Self {
-            method: http::Method::POST,
-            path: "/api/racer".to_string(),
-            ..Default::default()
-        }
+        Self::post("/api/racer", None, None, None)
+    }
+}
+
+impl Default for PostRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/puzzles/storm_dashboard.rs
+++ b/src/model/puzzles/storm_dashboard.rs
@@ -10,11 +10,14 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 impl GetRequest {
     pub fn new(username: &str, days: Option<u32>) -> Self {
         let path = format!("/api/storm/dashboard/{}", username);
-        Self {
-            path,
-            query: days.map(|x| GetQuery { days: x }),
-            ..Default::default()
-        }
+        let query = days.map(|x| GetQuery { days: x });
+        Self::get(path, query, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(s: S) -> Self {
+        Self::new(s.as_ref(), None)
     }
 }
 

--- a/src/model/studies/import_pgn_into_study.rs
+++ b/src/model/studies/import_pgn_into_study.rs
@@ -29,11 +29,7 @@ pub type PostRequest = Request<PostQuery, ImportPgnBody>;
 
 impl PostRequest {
     pub fn new(study_id: String, import_pgn_body: ImportPgnBody) -> Self {
-        Self {
-            method: http::Method::POST,
-            path: format!("/api/study/{}/import-pgn", study_id),
-            body: Body::Form(import_pgn_body),
-            ..Default::default()
-        }
+        let path = format!("/api/study/{study_id}/import-pgn");
+        Self::post(path, None, Body::Form(import_pgn_body), None)
     }
 }

--- a/src/model/tablebase/antichess.rs
+++ b/src/model/tablebase/antichess.rs
@@ -1,3 +1,4 @@
+use crate::model::{Domain, Request};
 use serde::Serialize;
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -5,17 +6,20 @@ pub struct GetQuery {
     fen: String,
 }
 
-pub type GetRequest = crate::model::Request<GetQuery>;
+pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
-    pub fn new(fen: &str) -> Self {
-        Self {
-            domain: crate::model::Domain::Tablebase,
-            path: "/antichess".to_string(),
-            query: Some(GetQuery {
-                fen: fen.to_string(),
-            }),
-            ..Default::default()
-        }
+    pub fn new(fen: impl Into<String>) -> Self {
+        Self::get(
+            "/antichess",
+            GetQuery { fen: fen.into() },
+            Some(Domain::Tablebase),
+        )
+    }
+}
+
+impl<S: Into<String>> From<S> for GetRequest {
+    fn from(fen: S) -> Self {
+        Self::new(fen)
     }
 }

--- a/src/model/tablebase/atomic.rs
+++ b/src/model/tablebase/atomic.rs
@@ -1,3 +1,4 @@
+use crate::model::{Domain, Request};
 use serde::Serialize;
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -5,17 +6,20 @@ pub struct GetQuery {
     fen: String,
 }
 
-pub type GetRequest = crate::model::Request<GetQuery>;
+pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
-    pub fn new(fen: &str) -> Self {
-        Self {
-            domain: crate::model::Domain::Tablebase,
-            path: "/atomic".to_string(),
-            query: Some(GetQuery {
-                fen: fen.to_string(),
-            }),
-            ..Default::default()
-        }
+    pub fn new(fen: impl Into<String>) -> Self {
+        Self::get(
+            "/atomic",
+            GetQuery { fen: fen.into() },
+            Some(Domain::Tablebase),
+        )
+    }
+}
+
+impl<S: Into<String>> From<S> for GetRequest {
+    fn from(fen: S) -> Self {
+        Self::new(fen)
     }
 }

--- a/src/model/tablebase/standard.rs
+++ b/src/model/tablebase/standard.rs
@@ -1,3 +1,4 @@
+use crate::model::{Domain, Request};
 use serde::Serialize;
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -5,17 +6,20 @@ pub struct GetQuery {
     fen: String,
 }
 
-pub type GetRequest = crate::model::Request<GetQuery>;
+pub type GetRequest = Request<GetQuery>;
 
 impl GetRequest {
-    pub fn new(fen: &str) -> Self {
-        Self {
-            domain: crate::model::Domain::Tablebase,
-            path: "/standard".to_string(),
-            query: Some(GetQuery {
-                fen: fen.to_string(),
-            }),
-            ..Default::default()
-        }
+    pub fn new(fen: impl Into<String>) -> Self {
+        Self::get(
+            "/standard",
+            GetQuery { fen: fen.into() },
+            Some(Domain::Tablebase),
+        )
+    }
+}
+
+impl<S: Into<String>> From<S> for GetRequest {
+    fn from(fen: S) -> Self {
+        Self::new(fen)
     }
 }

--- a/src/model/tv/channels.rs
+++ b/src/model/tv/channels.rs
@@ -7,9 +7,12 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/tv/channels".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/tv/channels", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/model/tv/games.rs
+++ b/src/model/tv/games.rs
@@ -18,12 +18,12 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(channel: ChannelName, query: Option<GetQuery>) -> Self {
-        let path = format!("/api/tv/{channel}");
+        Self::get(format!("/api/tv/{channel}"), query, None)
+    }
+}
 
-        Self {
-            path,
-            query,
-            ..Default::default()
-        }
+impl From<ChannelName> for GetRequest {
+    fn from(channel: ChannelName) -> Self {
+        Self::new(channel, None)
     }
 }

--- a/src/model/tv/stream/channel.rs
+++ b/src/model/tv/stream/channel.rs
@@ -8,11 +8,12 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(channel: ChannelName) -> Self {
-        let path = format!("/api/tv/{channel}/feed");
+        Self::get(format!("/api/tv/{channel}/feed"), None, None)
+    }
+}
 
-        Self {
-            path,
-            ..Default::default()
-        }
+impl From<ChannelName> for GetRequest {
+    fn from(channel: ChannelName) -> Self {
+        Self::new(channel)
     }
 }

--- a/src/model/tv/stream/current.rs
+++ b/src/model/tv/stream/current.rs
@@ -7,9 +7,12 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new() -> Self {
-        Self {
-            path: "/api/tv/feed".to_string(),
-            ..Default::default()
-        }
+        Self::get("/api/tv/feed", None, None)
+    }
+}
+
+impl Default for GetRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/model/users/public.rs
+++ b/src/model/users/public.rs
@@ -9,13 +9,10 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(username: &str, with_trophies: bool) -> Self {
-        let path = format!("/api/user/{}", username);
-        Self {
-            path,
-            query: Some(GetQuery {
-                trophies: with_trophies,
-            }),
-            ..Default::default()
-        }
+        let query = GetQuery {
+            trophies: with_trophies,
+        };
+
+        Self::get(format!("/api/user/{}", username), query, None)
     }
 }

--- a/src/model/users/status.rs
+++ b/src/model/users/status.rs
@@ -12,14 +12,14 @@ pub type GetRequest = crate::model::Request<GetQuery>;
 
 impl GetRequest {
     pub fn new(user_ids: Vec<String>, with_game_ids: bool) -> Self {
-        Self {
-            path: "/api/users/status".to_string(),
-            query: Some(GetQuery {
+        Self::get(
+            "/api/users/status",
+            Some(GetQuery {
                 ids: user_ids.join(","),
                 with_game_ids,
             }),
-            ..Default::default()
-        }
+            None,
+        )
     }
 }
 

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -1,13 +1,11 @@
 use lichess_api::client::*;
-use lichess_api::model::puzzles::daily;
 use reqwest;
 use tokio;
 
 #[tokio::test]
 pub async fn daily_puzzle() {
     let api = make_api(None);
-    let request = daily::GetRequest::new();
-    let response = api.get_daily_puzzle(request).await.unwrap();
+    let response = api.get_daily_puzzle().await.unwrap();
     println!("{:?}", response);
     assert!(!response.puzzle.id.is_empty());
 }


### PR DESCRIPTION
Improves the types used in `Client` methods and makes the API of these methods easier by:

1. Removing parameters which don't have any options.
2. Introduce `Default` implementations for `Request<_ , _>` where it makes sense.
3. Implements `From` for some `Request<_ , _>` and accepts `impl Into<Request<_ , _>>` in `Client` methods.

There is a question which came up while writing this PR,  `model::board::seek::PostRequest` has options which couldn't be set before, I left `PostRequest::new` as is but did implement `From<PostQuery>`. I think `PostRequest::new` should accept a `PostQuery`, though I may be missing something.

Closes #64