### PR TITLE
Added support for WASM

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      
+
       - name: install rust
         run: rustup update stable && rustup default stable
-      
+
       - name: lint
         run: cargo fmt --check
 
@@ -42,3 +42,18 @@ jobs:
 
       - name: test
         run: cargo test --verbose
+
+  wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Check
+        run: cargo check --target wasm32-unknown-unknown

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: install rust
-        run: rustup update stable && rustup default stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: lint
         run: cargo fmt --check
@@ -35,25 +35,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        run: rustup update stable && rustup default stable
-
-      - name: build
-        run: cargo build --verbose
-
-      - name: test
-        run: cargo test --verbose
-
-  wasm:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Check
-        run: cargo check --target wasm32-unknown-unknown
+      - name: build
+        run: cargo build --verbose
+
+      - name: wasm check
+        run: cargo check --verbose --target wasm32-unknown-unknown
+
+      - name: test
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ url = "2.5.2"
 [dev-dependencies]
 clap = { version = "4.5.17", features = ["derive"] }
 color-eyre = "0.6.3"
+getrandom = { version = "0.2.3", features = ["js"] }
+rand = "0.8.5"
 tokio = { version = "1.40.0", features = ["macros", "rt"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rand = "0.8.5"
-getrandom = { version = "0.2.3", features = ["js"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ url = "2.5.2"
 [dev-dependencies]
 clap = { version = "4.5.17", features = ["derive"] }
 color-eyre = "0.6.3"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.40.0", features = ["macros", "rt"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 rand = "0.8.5"
+getrandom = { version = "0.2.3", features = ["js"] }
 

--- a/examples/lichess.rs
+++ b/examples/lichess.rs
@@ -51,7 +51,7 @@ struct App {
     lichess: Lichess,
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
     let level = if args.verbose {

--- a/examples/lichess.rs
+++ b/examples/lichess.rs
@@ -51,7 +51,7 @@ struct App {
     lichess: Lichess,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let args = Cli::parse();
     let level = if args.verbose {

--- a/src/client.rs
+++ b/src/client.rs
@@ -66,8 +66,7 @@ impl LichessApi<reqwest::Client> {
         };
 
         let convert_err = |e: reqwest::Error| Error::Request(e.to_string());
-        let mut request = reqwest::Request::try_from(http_request).map_err(convert_err)?;
-        *request.timeout_mut() = None;
+        let request = reqwest::Request::try_from(http_request).map_err(convert_err)?;
         debug!(?request, "sending");
         let response = self.client.execute(request).await;
         debug!(?response, "received");

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -3,7 +3,7 @@ use lichess_api::model::puzzles::daily;
 use reqwest;
 use tokio;
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 pub async fn daily_puzzle() {
     let api = make_api(None);
     let request = daily::GetRequest::new();

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -3,7 +3,7 @@ use lichess_api::model::puzzles::daily;
 use reqwest;
 use tokio;
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 pub async fn daily_puzzle() {
     let api = make_api(None);
     let request = daily::GetRequest::new();


### PR DESCRIPTION
Makes the library WASM compatible by:

* Changing the feature `rt-multi-thread` to `rt`, since it's just for testing purposes and `rt-multi-thread` is not supported for WASM.
* Importing `getrandom` explicitly with `js` feature, so `rand` becomes WASM compatible.
* Removing the line `*request.timeout_mut() = None;`, because `timeout_mut` is not implemented for WASM (I originally had `#[cfg(not(target_arch = "wasm32"))]` above the line but I feel like the line is actually unnecessary there (looks like no timeout is the default value for the current version of Reqwest).

I have also added a check against the `wasm32-unknown-unknown` target as a part of the github workflows.