### PR TITLE
cargo: update dependencies, bump reqwest to 0.13 and rand to 0.10

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,11 +15,11 @@ path = "src/main.rs"
 
 [dependencies]
 lichess-api = { path = "../lib" }
-clap = { version = "4.5.32", features = ["derive"] }
-color-eyre = "0.6.3"
-futures = "0.3.31"
-rand = "0.9.0"
-reqwest = "0.12.7"
-tokio = { version = "1.44.1", features = ["macros", "rt"] }
-tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+clap = { version = "4.6.6", features = ["derive"] }
+color-eyre = "0.6.5"
+futures = "0.3.34"
+rand = "0.10.2"
+reqwest = "0.13.4"
+tokio = { version = "1.53.1", features = ["macros", "rt"] }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/cli/src/commands/external_engine.rs
+++ b/cli/src/commands/external_engine.rs
@@ -3,7 +3,7 @@ use color_eyre::Result;
 use futures::StreamExt;
 use lichess_api::client::LichessApi;
 use lichess_api::model::external_engine::{self, *};
-use rand::Rng;
+use rand::RngExt;
 use reqwest;
 
 type Lichess = LichessApi<reqwest::Client>;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,21 +12,20 @@ readme = "../README.md"
 
 [dependencies]
 # Library dependencies.
-async-std = "1.13.1"
-bytes = "1.10.1"
-futures = "0.3.31"
-futures-core = "0.3.31"
-http = "1.3.1"
+bytes = "1.12.1"
+futures = "0.3.34"
+futures-core = "0.3.34"
+http = "1.5.0"
 mime = "0.3.17"
-reqwest = { version = "0.12.7", features = ["json", "stream"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-serde_with = { version = "3.12.0", features = ["chrono"] }
+reqwest = { version = "0.13.4", features = ["json", "stream"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+serde_with = { version = "3.22.0", features = ["chrono"] }
 serde_urlencoded = "0.7.1"
-thiserror = "2.0.12"
-tracing = "0.1.41"
-url = "2.5.4"
+thiserror = "2.0.20"
+tracing = "0.1.44"
+url = "2.5.8"
 
 [dev-dependencies]
-tokio = { version = "1.45.1", features = ["macros", "rt"] }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tokio = { version = "1.53.1", features = ["macros", "rt"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/lib/src/api/board.rs
+++ b/lib/src/api/board.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/bot.rs
+++ b/lib/src/api/bot.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/external_engine.rs
+++ b/lib/src/api/external_engine.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/games.rs
+++ b/lib/src/api/games.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -17,7 +17,7 @@ pub mod tablebase;
 pub mod tv;
 pub mod users;
 
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::{Error, Result};

--- a/lib/src/api/openings.rs
+++ b/lib/src/api/openings.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/puzzles.rs
+++ b/lib/src/api/puzzles.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/relations.rs
+++ b/lib/src/api/relations.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/api/tv.rs
+++ b/lib/src/api/tv.rs
@@ -1,4 +1,4 @@
-use async_std::stream::StreamExt;
+use futures::stream::StreamExt;
 
 use crate::client::LichessApi;
 use crate::error::Result;

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -1,9 +1,8 @@
-use async_std::io::prelude::BufReadExt;
-use async_std::stream::StreamExt;
-
 use bytes::Bytes;
 
+use futures::AsyncBufReadExt;
 use futures::TryStreamExt;
+use futures::stream::StreamExt;
 
 use serde::de::DeserializeOwned;
 use tracing::debug;
@@ -97,10 +96,12 @@ impl LichessApi<reqwest::Client> {
             .map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
             .into_async_read()
             .lines()
-            .filter(|l| match l {
+            .filter(|l| {
                 // To avoid trying to serialize blank keep alive lines.
-                Ok(line) => !line.is_empty(),
-                Err(_) => true,
+                futures::future::ready(match l {
+                    Ok(line) => !line.is_empty(),
+                    Err(_) => true,
+                })
             })
             .map(|l| -> Result<String> {
                 let line = l?;


### PR DESCRIPTION
Drops async-std, which was only used for its StreamExt/BufReadExt trait re-exports (no runtime usage), in favor of the futures crate already used elsewhere in the client. reqwest 0.13's default TLS backend matches what was already resolved via hyper-rustls, and rand 0.10 splits sample_iter into a new RngExt trait.