### PR TITLE
teams: add teams category endpoints

### DIFF
--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod relations;
 pub mod simuls;
 pub mod studies;
 pub mod tablebase;
+pub mod teams;
 pub mod tv;
 pub mod users;
 

--- a/lib/src/api/teams.rs
+++ b/lib/src/api/teams.rs
@@ -1,0 +1,105 @@
+use futures::stream::StreamExt;
+
+use crate::client::LichessApi;
+use crate::error::Result;
+use crate::model::teams::*;
+use crate::model::{ArenaTournament, SwissTournament};
+
+impl LichessApi<reqwest::Client> {
+    pub async fn get_popular_teams(
+        &self,
+        request: impl Into<all::GetRequest>,
+    ) -> Result<TeamPaginatorJson> {
+        self.get_single_model(request.into()).await
+    }
+
+    pub async fn search_teams(
+        &self,
+        request: impl Into<search::GetRequest>,
+    ) -> Result<TeamPaginatorJson> {
+        self.get_single_model(request.into()).await
+    }
+
+    pub async fn get_teams_of_player(
+        &self,
+        request: impl Into<of_username::GetRequest>,
+    ) -> Result<Vec<Team>> {
+        self.get_single_model(request.into()).await
+    }
+
+    pub async fn get_team(&self, request: impl Into<show::GetRequest>) -> Result<Team> {
+        self.get_single_model(request.into()).await
+    }
+
+    pub async fn get_team_members(
+        &self,
+        request: impl Into<users::GetRequest>,
+    ) -> Result<impl StreamExt<Item = Result<users::TeamMember>>> {
+        self.get_streamed_models(request.into()).await
+    }
+
+    pub async fn get_team_arena_tournaments(
+        &self,
+        request: impl Into<arena::GetRequest>,
+    ) -> Result<impl StreamExt<Item = Result<ArenaTournament>>> {
+        self.get_streamed_models(request.into()).await
+    }
+
+    pub async fn get_team_swiss_tournaments(
+        &self,
+        request: impl Into<swiss::GetRequest>,
+    ) -> Result<impl StreamExt<Item = Result<SwissTournament>>> {
+        self.get_streamed_models(request.into()).await
+    }
+
+    pub async fn get_team_join_requests(
+        &self,
+        request: impl Into<requests::GetRequest>,
+    ) -> Result<Vec<TeamRequestWithUser>> {
+        self.get_single_model(request.into()).await
+    }
+
+    pub async fn accept_team_join_request(
+        &self,
+        request: impl Into<request_accept::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
+    }
+
+    pub async fn decline_team_join_request(
+        &self,
+        request: impl Into<request_decline::PostRequest>,
+    ) -> Result<bool> {
+        self.get_ok(request.into()).await
+    }
+
+    pub async fn kick_team_member(&self, request: impl Into<kick::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
+    }
+
+    pub async fn join_team(&self, request: impl Into<join::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
+    }
+
+    pub async fn quit_team(&self, request: impl Into<quit::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
+    }
+
+    pub async fn send_team_update(&self, request: impl Into<pm_all::PostRequest>) -> Result<bool> {
+        self.get_ok(request.into()).await
+    }
+
+    pub async fn get_team_updates(
+        &self,
+        request: impl Into<updates::GetRequest>,
+    ) -> Result<TeamUpdates> {
+        self.get_single_model(request.into()).await
+    }
+
+    pub async fn get_team_updates_of_team(
+        &self,
+        request: impl Into<updates_of_team::GetRequest>,
+    ) -> Result<TeamUpdatesOfTeam> {
+        self.get_single_model(request.into()).await
+    }
+}

--- a/lib/src/model/mod.rs
+++ b/lib/src/model/mod.rs
@@ -14,6 +14,7 @@ pub mod relations;
 pub mod simuls;
 pub mod studies;
 pub mod tablebase;
+pub mod teams;
 pub mod tv;
 pub mod users;
 
@@ -323,6 +324,8 @@ pub struct LightUser {
     pub title: Option<Title>,
     pub flair: Option<String>,
     pub patron: Option<bool>,
+    #[serde(rename = "patronColor")]
+    pub patron_color: Option<u8>,
     pub online: Option<bool>,
 }
 
@@ -449,4 +452,205 @@ impl Into<u32> for Days {
             Days::Fourteen => 14,
         }
     }
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArenaTournament {
+    pub id: String,
+    pub created_by: String,
+    pub system: String,
+    pub minutes: u32,
+    pub clock: ArenaClock,
+    pub rated: bool,
+    pub full_name: String,
+    pub nb_players: u32,
+    pub variant: Variant,
+    pub starts_at: i64,
+    pub finishes_at: i64,
+    pub status: ArenaStatus,
+    pub perf: ArenaPerf,
+    pub seconds_to_start: Option<i32>,
+    pub has_max_rating: Option<bool>,
+    pub max_rating: Option<ArenaRatingObj>,
+    pub min_rating: Option<ArenaRatingObj>,
+    pub min_rated_games: Option<ArenaMinRatedGames>,
+    pub bots_allowed: Option<bool>,
+    pub min_account_age_in_days: Option<i32>,
+    pub only_titled: Option<bool>,
+    pub team_member: Option<String>,
+    pub private: Option<bool>,
+    pub position: Option<ArenaPosition>,
+    pub schedule: Option<ArenaSchedule>,
+    pub team_battle: Option<ArenaTeamBattle>,
+    pub winner: Option<LightUser>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaClock {
+    pub limit: u32,
+    pub increment: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArenaStatus {
+    Created,
+    Started,
+    Finished,
+}
+
+impl Serialize for ArenaStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value: u8 = match self {
+            ArenaStatus::Created => 10,
+            ArenaStatus::Started => 20,
+            ArenaStatus::Finished => 30,
+        };
+        value.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ArenaStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u8::deserialize(deserializer)?;
+        match value {
+            10 => Ok(ArenaStatus::Created),
+            20 => Ok(ArenaStatus::Started),
+            30 => Ok(ArenaStatus::Finished),
+            _ => Err(serde::de::Error::custom(format!(
+                "invalid arena tournament status {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArenaStatusName {
+    Created,
+    Started,
+    Finished,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaPerf {
+    pub key: PerfType,
+    pub name: String,
+    pub position: i32,
+    pub icon: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaRatingObj {
+    pub perf: Option<PerfType>,
+    pub rating: i32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaMinRatedGames {
+    pub nb: Option<i32>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ArenaPosition {
+    Thematic {
+        eco: String,
+        name: String,
+        fen: String,
+        url: String,
+    },
+    Custom {
+        name: String,
+        fen: String,
+    },
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaSchedule {
+    pub freq: Option<String>,
+    pub speed: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ArenaTeamBattle {
+    pub teams: Option<Vec<String>>,
+    pub nb_leaders: Option<i32>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwissTournament {
+    pub id: String,
+    pub created_by: String,
+    pub starts_at: String,
+    pub name: String,
+    pub clock: SwissClock,
+    pub variant: VariantKey,
+    pub round: i32,
+    pub nb_rounds: i32,
+    pub nb_players: i32,
+    pub nb_ongoing: i32,
+    pub status: SwissStatus,
+    pub stats: Option<SwissStats>,
+    pub rated: bool,
+    pub verdicts: Verdicts,
+    pub next_round: Option<SwissNextRound>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SwissClock {
+    pub limit: i32,
+    pub increment: i32,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SwissStatus {
+    Created,
+    Started,
+    Finished,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwissStats {
+    pub games: i32,
+    pub white_wins: i32,
+    pub black_wins: i32,
+    pub draws: i32,
+    pub byes: i32,
+    pub absences: i32,
+    pub average_rating: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SwissNextRound {
+    pub at: String,
+    #[serde(rename = "in")]
+    pub in_seconds: i32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Verdicts {
+    pub accepted: bool,
+    pub list: Vec<Verdict>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Verdict {
+    pub condition: String,
+    pub verdict: String,
 }

--- a/lib/src/model/teams/all.rs
+++ b/lib/src/model/teams/all.rs
@@ -1,0 +1,28 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub page: Option<u32>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(query: GetQuery) -> Self {
+        Self::get("/api/team/all", query, None)
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
+    }
+}
+
+impl From<Option<u32>> for GetRequest {
+    fn from(page: Option<u32>) -> Self {
+        Self::new(GetQuery { page })
+    }
+}

--- a/lib/src/model/teams/arena.rs
+++ b/lib/src/model/teams/arena.rs
@@ -1,0 +1,20 @@
+use crate::model::{ArenaStatusName, Request};
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub max: Option<u32>,
+    pub status: Option<ArenaStatusName>,
+    pub created_by: Option<String>,
+    pub name: Option<String>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(team_id: &str, query: GetQuery) -> Self {
+        Self::get(format!("/api/team/{team_id}/arena"), query, None)
+    }
+}

--- a/lib/src/model/teams/join.rs
+++ b/lib/src/model/teams/join.rs
@@ -1,0 +1,32 @@
+use crate::model::{Body, Request};
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct JoinForm {
+    pub message: Option<String>,
+    pub password: Option<String>,
+}
+
+pub type PostRequest = Request<PostQuery, JoinForm>;
+
+impl PostRequest {
+    pub fn new(team_id: &str, form: JoinForm) -> Self {
+        Self::post(
+            format!("/team/{team_id}/join"),
+            None,
+            Body::Form(form),
+            None,
+        )
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(team_id: S) -> Self {
+        Self::new(team_id.as_ref(), JoinForm::default())
+    }
+}

--- a/lib/src/model/teams/kick.rs
+++ b/lib/src/model/teams/kick.rs
@@ -1,0 +1,24 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery>;
+
+impl PostRequest {
+    pub fn new(team_id: &str, user_id: &str) -> Self {
+        Self::post(
+            format!("/api/team/{team_id}/kick/{user_id}"),
+            None,
+            None,
+            None,
+        )
+    }
+}
+
+impl<S: AsRef<str>> From<(S, S)> for PostRequest {
+    fn from((team_id, user_id): (S, S)) -> Self {
+        Self::new(team_id.as_ref(), user_id.as_ref())
+    }
+}

--- a/lib/src/model/teams/mod.rs
+++ b/lib/src/model/teams/mod.rs
@@ -1,0 +1,117 @@
+pub mod all;
+pub mod arena;
+pub mod join;
+pub mod kick;
+pub mod of_username;
+pub mod pm_all;
+pub mod quit;
+pub mod request_accept;
+pub mod request_decline;
+pub mod requests;
+pub mod search;
+pub mod show;
+pub mod swiss;
+pub mod updates;
+pub mod updates_of_team;
+pub mod users;
+
+use crate::model::LightUser;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Team {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub flair: Option<String>,
+    pub leader: Option<LightUser>,
+    pub leaders: Option<Vec<LightUser>>,
+    #[serde(rename = "nbMembers")]
+    pub nb_members: Option<u32>,
+    pub open: Option<bool>,
+    pub joined: Option<bool>,
+    pub requested: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LightTeam {
+    pub id: String,
+    pub name: String,
+    pub flair: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamPaginator<T> {
+    pub current_page: u32,
+    pub max_per_page: u32,
+    pub current_page_results: Vec<T>,
+    pub previous_page: Option<u32>,
+    pub next_page: Option<u32>,
+    pub nb_results: u32,
+    pub nb_pages: u32,
+}
+
+pub type TeamPaginatorJson = TeamPaginator<Team>;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamRequest {
+    pub team_id: String,
+    pub user_id: String,
+    pub date: u64,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamRequestWithUser {
+    pub request: TeamRequest,
+    pub user: crate::model::users::User,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamUpdate {
+    pub msg: TeamUpdateMessage,
+    pub seen: bool,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamUpdateMessage {
+    pub id: String,
+    pub date: u64,
+    pub sender: LightUser,
+    pub team: LightTeam,
+    pub text: String,
+}
+
+pub type TeamUpdatesPager = TeamPaginator<TeamUpdate>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamUpdatesByTeamEntry {
+    pub team: LightTeam,
+    pub last: u64,
+    pub unread: u32,
+}
+
+pub type TeamUpdatesByTeam = Vec<TeamUpdatesByTeamEntry>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamUpdates {
+    pub updates: TeamUpdatesPager,
+    #[serde(rename = "byTeam")]
+    pub by_team: TeamUpdatesByTeam,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamUpdatesOfTeam {
+    pub team: LightTeam,
+    pub subscribed: bool,
+    pub updates: TeamUpdatesPager,
+    #[serde(rename = "byTeam")]
+    pub by_team: TeamUpdatesByTeam,
+}

--- a/lib/src/model/teams/of_username.rs
+++ b/lib/src/model/teams/of_username.rs
@@ -1,0 +1,19 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery;
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(username: &str) -> Self {
+        Self::get(format!("/api/team/of/{username}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(username: S) -> Self {
+        Self::new(username.as_ref())
+    }
+}

--- a/lib/src/model/teams/pm_all.rs
+++ b/lib/src/model/teams/pm_all.rs
@@ -1,0 +1,27 @@
+use crate::model::{Body, Request};
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PmAllForm {
+    pub message: String,
+}
+
+pub type PostRequest = Request<PostQuery, PmAllForm>;
+
+impl PostRequest {
+    pub fn new(team_id: &str, message: impl Into<String>) -> Self {
+        let form = PmAllForm {
+            message: message.into(),
+        };
+
+        Self::post(
+            format!("/team/{team_id}/pm-all"),
+            None,
+            Body::Form(form),
+            None,
+        )
+    }
+}

--- a/lib/src/model/teams/quit.rs
+++ b/lib/src/model/teams/quit.rs
@@ -1,0 +1,19 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery>;
+
+impl PostRequest {
+    pub fn new(team_id: &str) -> Self {
+        Self::post(format!("/team/{team_id}/quit"), None, None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PostRequest {
+    fn from(team_id: S) -> Self {
+        Self::new(team_id.as_ref())
+    }
+}

--- a/lib/src/model/teams/request_accept.rs
+++ b/lib/src/model/teams/request_accept.rs
@@ -1,0 +1,24 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery>;
+
+impl PostRequest {
+    pub fn new(team_id: &str, user_id: &str) -> Self {
+        Self::post(
+            format!("/api/team/{team_id}/request/{user_id}/accept"),
+            None,
+            None,
+            None,
+        )
+    }
+}
+
+impl<S: AsRef<str>> From<(S, S)> for PostRequest {
+    fn from((team_id, user_id): (S, S)) -> Self {
+        Self::new(team_id.as_ref(), user_id.as_ref())
+    }
+}

--- a/lib/src/model/teams/request_decline.rs
+++ b/lib/src/model/teams/request_decline.rs
@@ -1,0 +1,24 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PostQuery;
+
+pub type PostRequest = Request<PostQuery>;
+
+impl PostRequest {
+    pub fn new(team_id: &str, user_id: &str) -> Self {
+        Self::post(
+            format!("/api/team/{team_id}/request/{user_id}/decline"),
+            None,
+            None,
+            None,
+        )
+    }
+}
+
+impl<S: AsRef<str>> From<(S, S)> for PostRequest {
+    fn from((team_id, user_id): (S, S)) -> Self {
+        Self::new(team_id.as_ref(), user_id.as_ref())
+    }
+}

--- a/lib/src/model/teams/requests.rs
+++ b/lib/src/model/teams/requests.rs
@@ -1,0 +1,23 @@
+use crate::model::Request;
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub declined: Option<bool>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(team_id: &str, query: GetQuery) -> Self {
+        Self::get(format!("/api/team/{team_id}/requests"), query, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(team_id: S) -> Self {
+        Self::new(team_id.as_ref(), GetQuery::default())
+    }
+}

--- a/lib/src/model/teams/search.rs
+++ b/lib/src/model/teams/search.rs
@@ -1,0 +1,23 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub text: Option<String>,
+    pub page: Option<u32>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(query: GetQuery) -> Self {
+        Self::get("/api/team/search", query, None)
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
+    }
+}

--- a/lib/src/model/teams/show.rs
+++ b/lib/src/model/teams/show.rs
@@ -1,0 +1,19 @@
+use crate::model::Request;
+use serde::Serialize;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery;
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(team_id: &str) -> Self {
+        Self::get(format!("/api/team/{team_id}"), None, None)
+    }
+}
+
+impl<S: AsRef<str>> From<S> for GetRequest {
+    fn from(team_id: S) -> Self {
+        Self::new(team_id.as_ref())
+    }
+}

--- a/lib/src/model/teams/swiss.rs
+++ b/lib/src/model/teams/swiss.rs
@@ -1,0 +1,20 @@
+use crate::model::{Request, SwissStatus};
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub max: Option<u32>,
+    pub status: Option<SwissStatus>,
+    pub created_by: Option<String>,
+    pub name: Option<String>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(team_id: &str, query: GetQuery) -> Self {
+        Self::get(format!("/api/team/{team_id}/swiss"), query, None)
+    }
+}

--- a/lib/src/model/teams/updates.rs
+++ b/lib/src/model/teams/updates.rs
@@ -1,0 +1,29 @@
+use crate::model::Request;
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub page: Option<u32>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(query: GetQuery) -> Self {
+        Self::get("/team/updates", query, None)
+    }
+}
+
+impl From<GetQuery> for GetRequest {
+    fn from(query: GetQuery) -> Self {
+        Self::new(query)
+    }
+}
+
+impl From<Option<u32>> for GetRequest {
+    fn from(page: Option<u32>) -> Self {
+        Self::new(GetQuery { page })
+    }
+}

--- a/lib/src/model/teams/updates_of_team.rs
+++ b/lib/src/model/teams/updates_of_team.rs
@@ -1,0 +1,17 @@
+use crate::model::Request;
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub page: Option<u32>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(team_id: &str, query: GetQuery) -> Self {
+        Self::get(format!("/team/updates/{team_id}"), query, None)
+    }
+}

--- a/lib/src/model/teams/users.rs
+++ b/lib/src/model/teams/users.rs
@@ -1,0 +1,29 @@
+use crate::model::{Request, Title};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct GetQuery {
+    pub full: Option<bool>,
+}
+
+pub type GetRequest = Request<GetQuery>;
+
+impl GetRequest {
+    pub fn new(team_id: &str, query: GetQuery) -> Self {
+        Self::get(format!("/api/team/{team_id}/users"), query, None)
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TeamMember {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "joinedTeamAt")]
+    pub joined_team_at: u64,
+    pub title: Option<Title>,
+    #[serde(rename = "patronColor")]
+    pub patron_color: Option<u8>,
+}

--- a/lib/tests/data/response/arena_tournament.json
+++ b/lib/tests/data/response/arena_tournament.json
@@ -1,0 +1,17 @@
+{
+  "id": "LojvlQOo",
+  "createdBy": "natebrady23",
+  "system": "arena",
+  "minutes": 60,
+  "clock": { "limit": 300, "increment": 3 },
+  "rated": false,
+  "fullName": "Return of the BBB No. 140 Arena",
+  "nbPlayers": 12,
+  "variant": { "key": "standard", "short": "Std", "name": "Standard" },
+  "startsAt": 1762914600000,
+  "finishesAt": 1762918200000,
+  "status": 30,
+  "perf": { "key": "blitz", "name": "Blitz", "position": 1, "icon": ")" },
+  "teamMember": "bradys-blunder-buddies",
+  "winner": { "name": "Mennonite", "flair": "objects.closed-mailbox-with-raised-flag", "id": "mennonite" }
+}

--- a/lib/tests/data/response/swiss_tournament.json
+++ b/lib/tests/data/response/swiss_tournament.json
@@ -1,0 +1,22 @@
+{
+  "id": "KmevwnGY",
+  "createdBy": "lichess",
+  "startsAt": "2026-07-10T23:30:00Z",
+  "name": "Rapid Increment",
+  "clock": { "limit": 420, "increment": 2 },
+  "variant": "standard",
+  "round": 0,
+  "nbRounds": 7,
+  "nbPlayers": 0,
+  "nbOngoing": 0,
+  "status": "created",
+  "nextRound": { "at": "2026-07-10T23:30:00Z", "in": 336831 },
+  "verdicts": {
+    "list": [
+      { "condition": "≥ 8 rated Rapid games", "verdict": "ok" },
+      { "condition": "Play your games", "verdict": "ok" }
+    ],
+    "accepted": true
+  },
+  "rated": true
+}

--- a/lib/tests/data/response/team.json
+++ b/lib/tests/data/response/team.json
@@ -1,0 +1,15 @@
+{
+  "id": "lichess-swiss",
+  "name": "Lichess Swiss",
+  "description": "The official Lichess Swiss team. We organize regular swiss tournaments for all to join.",
+  "open": true,
+  "leader": { "name": "Lichess", "flair": "activity.lichess", "patron": true, "patronColor": 10, "id": "lichess" },
+  "nbMembers": 715566,
+  "flair": "food-drink.cheese-wedge",
+  "leaders": [
+    { "name": "thibault", "flair": "nature.seedling", "patron": true, "patronColor": 10, "id": "thibault" },
+    { "name": "Lichess", "flair": "activity.lichess", "patron": true, "patronColor": 10, "id": "lichess" }
+  ],
+  "joined": false,
+  "requested": false
+}

--- a/lib/tests/data/response/team_member.json
+++ b/lib/tests/data/response/team_member.json
@@ -1,0 +1,5 @@
+{
+  "joinedTeamAt": 1716930043067,
+  "id": "chess-network",
+  "name": "Chess-Network"
+}

--- a/lib/tests/data/response/team_paginator.json
+++ b/lib/tests/data/response/team_paginator.json
@@ -1,0 +1,34 @@
+{
+  "currentPage": 1,
+  "maxPerPage": 15,
+  "currentPageResults": [
+    {
+      "id": "coders",
+      "name": "Coders",
+      "description": "If you want to join the team, prove (briefly) that you can code in the request message!",
+      "open": false,
+      "leader": { "name": "thibault", "flair": "nature.seedling", "patron": true, "patronColor": 10, "id": "thibault" },
+      "nbMembers": 492,
+      "flair": "objects.hammer-and-wrench",
+      "leaders": [
+        { "name": "thibault", "flair": "nature.seedling", "patron": true, "patronColor": 10, "id": "thibault" }
+      ]
+    },
+    {
+      "id": "f5-coders",
+      "name": "f5 coders",
+      "description": "Equipo de coders de factoria f5.\r\nRompemos el código y los tableros.",
+      "open": false,
+      "leader": { "name": "RogerAiguas", "id": "rogeraiguas" },
+      "nbMembers": 16,
+      "leaders": [
+        { "name": "RogerAiguas", "id": "rogeraiguas" },
+        { "name": "ABPNET", "id": "abpnet" }
+      ]
+    }
+  ],
+  "previousPage": null,
+  "nextPage": 2,
+  "nbResults": 30,
+  "nbPages": 2
+}

--- a/lib/tests/data/response/team_request_with_user.json
+++ b/lib/tests/data/response/team_request_with_user.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "userId": "mary",
+    "teamId": "my-private-team",
+    "message": "Hello, I would like to join the team!",
+    "date": 1745112259637
+  },
+  "user": {
+    "id": "mary",
+    "username": "Mary",
+    "perfs": {
+      "bullet": { "games": 119, "rating": 1066, "rd": 101, "prog": -1 },
+      "blitz": { "games": 34, "rating": 1007, "rd": 55, "prog": -59 },
+      "rapid": { "games": 134, "rating": 1021, "rd": 70, "prog": 26 },
+      "classical": { "games": 451, "rating": 1136, "rd": 78, "prog": -1 },
+      "correspondence": { "games": 35, "rating": 1049, "rd": 45, "prog": 15 },
+      "chess960": { "games": 52, "rating": 996, "rd": 72, "prog": -9 },
+      "kingOfTheHill": { "games": 1998, "rating": 1169, "rd": 79, "prog": -13 },
+      "threeCheck": { "games": 6, "rating": 946, "rd": 52, "prog": 32 },
+      "antichess": { "games": 79, "rating": 1143, "rd": 48, "prog": 61 },
+      "atomic": { "games": 239, "rating": 978, "rd": 76, "prog": 22 },
+      "horde": { "games": 246, "rating": 1031, "rd": 108, "prog": -28 },
+      "crazyhouse": { "games": 473, "rating": 1063, "rd": 88, "prog": 2 },
+      "puzzle": { "games": 37, "rating": 977, "rd": 86, "prog": 26 }
+    },
+    "flair": "food-drink.coconut",
+    "createdAt": 1744526339498,
+    "seenAt": 1745112249912,
+    "playTime": { "total": 14336, "tv": 0 }
+  }
+}

--- a/lib/tests/data/response/team_updates.json
+++ b/lib/tests/data/response/team_updates.json
@@ -1,0 +1,52 @@
+{
+  "byTeam": [
+    { "last": 1785681992878, "team": { "id": "lichess-chess960", "name": "Lichess Chess960" }, "unread": 0 },
+    {
+      "last": 1785594732863,
+      "team": { "flair": "objects.hammer-and-wrench", "id": "coders", "name": "Coders" },
+      "unread": 6
+    }
+  ],
+  "updates": {
+    "currentPage": 1,
+    "currentPageResults": [
+      {
+        "msg": {
+          "date": 1785681992878,
+          "id": "3gJtsRcB",
+          "sender": {
+            "name": "thibault",
+            "flair": "nature.seedling",
+            "patron": true,
+            "patronColor": 10,
+            "id": "thibault"
+          },
+          "team": { "id": "lichess-chess960", "name": "Lichess Chess960" },
+          "text": "New regulations for the 2022 FIDE World Fischer Random Chess Championship"
+        },
+        "seen": true
+      },
+      {
+        "msg": {
+          "date": 1785594732863,
+          "id": "CjLyCrW9",
+          "sender": {
+            "name": "thibault",
+            "flair": "nature.seedling",
+            "patron": true,
+            "patronColor": 10,
+            "id": "thibault"
+          },
+          "team": { "flair": "objects.hammer-and-wrench", "id": "coders", "name": "Coders" },
+          "text": "Some fascinating update about the coders team"
+        },
+        "seen": false
+      }
+    ],
+    "maxPerPage": 6,
+    "nbPages": 8,
+    "nbResults": 46,
+    "nextPage": 2,
+    "previousPage": null
+  }
+}

--- a/lib/tests/data/response/team_updates_of_team.json
+++ b/lib/tests/data/response/team_updates_of_team.json
@@ -1,0 +1,38 @@
+{
+  "team": { "id": "lichess-chess960", "name": "Lichess Chess960" },
+  "subscribed": true,
+  "byTeam": [
+    { "last": 1785681992878, "team": { "id": "lichess-chess960", "name": "Lichess Chess960" }, "unread": 0 },
+    {
+      "last": 1785594732863,
+      "team": { "flair": "objects.hammer-and-wrench", "id": "coders", "name": "Coders" },
+      "unread": 6
+    }
+  ],
+  "updates": {
+    "currentPage": 1,
+    "currentPageResults": [
+      {
+        "msg": {
+          "date": 1785681992878,
+          "id": "3gJtsRcB",
+          "sender": {
+            "name": "thibault",
+            "flair": "nature.seedling",
+            "patron": true,
+            "patronColor": 10,
+            "id": "thibault"
+          },
+          "team": { "id": "lichess-chess960", "name": "Lichess Chess960" },
+          "text": "New regulations for the 2022 FIDE World Fischer Random Chess Championship"
+        },
+        "seen": true
+      }
+    ],
+    "maxPerPage": 6,
+    "nbPages": 1,
+    "nbResults": 1,
+    "nextPage": null,
+    "previousPage": null
+  }
+}

--- a/lib/tests/offline.rs
+++ b/lib/tests/offline.rs
@@ -115,6 +115,18 @@ pub fn challenges() {
     test_response_model::<challenges::ChallengeDeclinedJson>("challenge_declined_json");
 }
 
+#[test]
+pub fn teams() {
+    test_response_model::<teams::Team>("team");
+    test_response_model::<teams::TeamPaginatorJson>("team_paginator");
+    test_response_model::<teams::TeamRequestWithUser>("team_request_with_user");
+    test_response_model::<teams::TeamUpdates>("team_updates");
+    test_response_model::<teams::TeamUpdatesOfTeam>("team_updates_of_team");
+    test_response_model::<teams::users::TeamMember>("team_member");
+    test_response_model::<ArenaTournament>("arena_tournament");
+    test_response_model::<SwissTournament>("swiss_tournament");
+}
+
 fn test_response_model<Model: Serialize + DeserializeOwned>(file_name: &str) {
     let path = format!("./tests/data/response/{}.json", file_name);
     test_model::<Model>(path);


### PR DESCRIPTION
Implements all 16 Teams operations (get/search/join/leave/kick/requests/
updates/members/arena/swiss tournaments of a team). Adds ArenaTournament
and SwissTournament as shared model types since they're proper API
schemas referenced by Teams now and will be reused by the Tournament
(Arena/Swiss) categories later. Also adds the missing patronColor field
to the shared LightUser type to match the real schema.

Closes #24 
